### PR TITLE
Use larger runner for publish job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       always() &&
       github.event_name == 'push' &&
       needs.build.result == 'success'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     timeout-minutes: 15
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Updates the publish job to use ubuntu-latest-large runner to avoid timeout issues.