### PR TITLE
hylo-quotes: fix UsdcExchangeState.swap_fee precision (N9 → N4)

### DIFF
--- a/hylo-quotes/src/protocol_state/state.rs
+++ b/hylo-quotes/src/protocol_state/state.rs
@@ -32,8 +32,16 @@ use crate::LST;
 pub struct UsdcExchangeState {
   /// USDC/USD oracle price range
   pub usdc_usd_price: hylo_core::pyth::PriceRange<N9>,
-  /// Swap fee extracted on USDC operations
-  pub swap_fee: UFix64<N9>,
+  /// Swap fee extracted on USDC operations.
+  ///
+  /// Precision is `N4` (0.01 bps increments), matching the on-chain
+  /// contract in `hylo_exchange::state::UsdcPair::swap_fee` which is
+  /// validated via `AssetSwapConfig::validate_fee(_: UFix64<N4>)` on
+  /// initialize/update. Storing as `N9` would force a non-matching
+  /// `UFixValue64::try_into::<UFix64<N9>>()` at construction and fail
+  /// with `InvalidNumericConversion` (hylo-fix's `TryFrom` is
+  /// strict-equal on `exp`).
+  pub swap_fee: UFix64<N4>,
 }
 
 impl UsdcExchangeState {
@@ -51,7 +59,7 @@ impl UsdcExchangeState {
   /// * Arithmetic failure in fee extraction
   pub fn apply_fee<Exp>(&self, amount: UFix64<Exp>) -> Result<FeeExtract<Exp>>
   where
-    UFix64<N9>: FixExt,
+    UFix64<N4>: FixExt,
   {
     Ok(FeeExtract::new(self.swap_fee, amount)?)
   }


### PR DESCRIPTION
`UsdcExchangeState.swap_fee` is declared `UFix64<N9>` but the on-chain contract stores and validates `UFix64<N4>` (`hylo_exchange::state::UsdcPair::swap_fee`, validated via `AssetSwapConfig::validate_fee(_: UFix64<N4>)` on initialize/update).

Reading an on-chain value with `exp=-4` into the N9 field fails `hylo-fix`'s strict-equal `TryFrom<UFixValue64>` with `InvalidNumericConversion`. Fixing the field type to `UFix64<N4>` aligns consumer and contract.

No API surface change.