### PR TITLE
Clamp rebalance curve floor/ceil to deviation tolerance

### DIFF
--- a/hylo-clients/src/earn_pool_client.rs
+++ b/hylo-clients/src/earn_pool_client.rs
@@ -86,4 +86,33 @@ impl EarnPoolClient {
     let inner = VersionedTransactionData::one(instruction);
     squads.build_proposal(&inner, self.program.payer(), memo)
   }
+
+  /// Pauses the earn pool.
+  ///
+  /// # Errors
+  /// * Failed to build transaction instructions
+  pub fn pause_earn_pool(
+    &self,
+    squads: &SquadsContext,
+  ) -> Result<SquadsTransactionData> {
+    let instruction = instruction_builders::pause_earn_pool(squads.vault_pda());
+    let memo = build_memo("pause_earn_pool", &instruction);
+    let inner = VersionedTransactionData::one(instruction);
+    squads.build_proposal(&inner, self.program.payer(), memo)
+  }
+
+  /// Unpauses the earn pool.
+  ///
+  /// # Errors
+  /// * Failed to build transaction instructions
+  pub fn unpause_earn_pool(
+    &self,
+    squads: &SquadsContext,
+  ) -> Result<SquadsTransactionData> {
+    let instruction =
+      instruction_builders::unpause_earn_pool(squads.vault_pda());
+    let memo = build_memo("unpause_earn_pool", &instruction);
+    let inner = VersionedTransactionData::one(instruction);
+    squads.build_proposal(&inner, self.program.payer(), memo)
+  }
 }

--- a/hylo-clients/src/prelude.rs
+++ b/hylo-clients/src/prelude.rs
@@ -4,7 +4,9 @@ pub use anchor_client::Cluster;
 pub use anchor_lang::prelude::Pubkey;
 pub use anyhow::Result;
 pub use fix::prelude::*;
-pub use hylo_core::idl::tokens::{HYUSD, JITOSOL, SHYUSD, XSOL};
+pub use hylo_core::idl::tokens::{
+  CBBTC, HYLOSOL, HYUSD, JITOSOL, SHYUSD, USDC, XBTC, XSOL,
+};
 
 pub use crate::earn_pool_client::EarnPoolClient;
 pub use crate::exchange_client::ExchangeClient;

--- a/hylo-core/src/rebalance/pricing.rs
+++ b/hylo-core/src/rebalance/pricing.rs
@@ -120,21 +120,29 @@ fn scale_ci(ci: UFix64<N9>, mult: UFix64<N2>) -> Result<UFix64<N9>> {
     .ok_or(CoreError::RebalancePriceConstruction.into())
 }
 
-/// Checks `|projected_price - spot_price| / spot_price <= tolerance`.
+/// Clamps `projected_price` into `spot_price ± spot_price * tolerance`.
 ///
 /// # Errors
-/// * Deviation exceeded or arithmetic overflow.
-fn check_deviation(
+/// * Arithmetic overflow computing the tolerance band.
+fn clamp_to_tolerance(
   spot_price: UFix64<N9>,
   projected_price: UFix64<N9>,
   tolerance: UFix64<N9>,
-) -> Result<()> {
+) -> Result<UFix64<N9>> {
   let max_delta = spot_price
     .mul_div_ceil(tolerance, UFix64::<N9>::one())
     .ok_or(CoreError::RebalanceDeviationArithmetic)?;
-  (spot_price.abs_diff(&projected_price) <= max_delta)
-    .then_some(())
-    .ok_or(CoreError::RebalanceDeviationExceeded.into())
+  if spot_price.abs_diff(&projected_price) <= max_delta {
+    Ok(projected_price)
+  } else if projected_price < spot_price {
+    spot_price
+      .checked_sub(&max_delta)
+      .ok_or(CoreError::RebalanceDeviationArithmetic.into())
+  } else {
+    spot_price
+      .checked_add(&max_delta)
+      .ok_or(CoreError::RebalanceDeviationArithmetic.into())
+  }
 }
 
 /// Interpolated rebalance price controller.
@@ -192,12 +200,12 @@ impl SellPriceCurve {
     config: &RebalanceCurveConfig,
     deviation_tolerance: UFix64<N9>,
   ) -> Result<SellPriceCurve> {
-    let (floor, ceil) = spot
+    let (raw_floor, raw_ceil) = spot
       .checked_sub(&scale_ci(conf, config.floor_mult()?)?)
       .zip(spot.checked_add(&scale_ci(conf, config.ceil_mult()?)?))
       .ok_or(CoreError::RebalancePriceConstruction)?;
-    check_deviation(spot, floor, deviation_tolerance)?;
-    check_deviation(spot, ceil, deviation_tolerance)?;
+    let floor = clamp_to_tolerance(spot, raw_floor, deviation_tolerance)?;
+    let ceil = clamp_to_tolerance(spot, raw_ceil, deviation_tolerance)?;
     let sell_zone_1 = RebalanceMode::SellZone1.active_range();
     let curve = FixInterp::from_points([
       Point {
@@ -260,12 +268,12 @@ impl BuyPriceCurve {
     config: &RebalanceCurveConfig,
     deviation_tolerance: UFix64<N9>,
   ) -> Result<BuyPriceCurve> {
-    let (floor, ceil) = spot
+    let (raw_floor, raw_ceil) = spot
       .checked_sub(&scale_ci(conf, config.floor_mult()?)?)
       .zip(spot.checked_add(&scale_ci(conf, config.ceil_mult()?)?))
       .ok_or(CoreError::RebalancePriceConstruction)?;
-    check_deviation(spot, floor, deviation_tolerance)?;
-    check_deviation(spot, ceil, deviation_tolerance)?;
+    let floor = clamp_to_tolerance(spot, raw_floor, deviation_tolerance)?;
+    let ceil = clamp_to_tolerance(spot, raw_ceil, deviation_tolerance)?;
     let buy_zone_1 = RebalanceMode::BuyZone1.active_range();
     let curve = FixInterp::from_points([
       Point {
@@ -359,29 +367,59 @@ mod tests {
   }
 
   #[test]
-  fn sell_rejects_deviation_exceeded() {
+  fn sell_clamps_to_tolerance() -> Result<()> {
     let wide_ci = OraclePrice {
       conf: UFix64::constant(14_000_000_000),
       ..ORACLE
     };
-    let res = SellPriceCurve::new(wide_ci, &SELL_CONFIG, DEVIATION_5_PCT);
-    assert_eq!(
-      res.err(),
-      Some(CoreError::RebalanceDeviationExceeded.into())
-    );
+    let curve = SellPriceCurve::new(wide_ci, &SELL_CONFIG, DEVIATION_5_PCT)?;
+    let max_delta = ORACLE
+      .spot
+      .mul_div_ceil(DEVIATION_5_PCT, UFix64::<N9>::one())
+      .ok_or(CoreError::RebalanceDeviationArithmetic)?;
+    let expected_floor: IFix64<N9> = ORACLE
+      .spot
+      .checked_sub(&max_delta)
+      .ok_or(CoreError::RebalanceDeviationArithmetic)?
+      .narrow()
+      .ok_or(CoreError::RebalancePriceConversion)?;
+    let expected_ceil: IFix64<N9> = ORACLE
+      .spot
+      .checked_add(&max_delta)
+      .ok_or(CoreError::RebalanceDeviationArithmetic)?
+      .narrow()
+      .ok_or(CoreError::RebalancePriceConversion)?;
+    assert_eq!(curve.curve().y_min(), expected_floor);
+    assert_eq!(curve.curve().y_max(), expected_ceil);
+    Ok(())
   }
 
   #[test]
-  fn buy_rejects_deviation_exceeded() {
+  fn buy_clamps_to_tolerance() -> Result<()> {
     let wide_ci = OraclePrice {
       conf: UFix64::constant(14_000_000_000),
       ..ORACLE
     };
-    let res = BuyPriceCurve::new(wide_ci, &BUY_CONFIG, DEVIATION_5_PCT);
-    assert_eq!(
-      res.err(),
-      Some(CoreError::RebalanceDeviationExceeded.into())
-    );
+    let curve = BuyPriceCurve::new(wide_ci, &BUY_CONFIG, DEVIATION_5_PCT)?;
+    let max_delta = ORACLE
+      .spot
+      .mul_div_ceil(DEVIATION_5_PCT, UFix64::<N9>::one())
+      .ok_or(CoreError::RebalanceDeviationArithmetic)?;
+    let expected_floor: IFix64<N9> = ORACLE
+      .spot
+      .checked_sub(&max_delta)
+      .ok_or(CoreError::RebalanceDeviationArithmetic)?
+      .narrow()
+      .ok_or(CoreError::RebalancePriceConversion)?;
+    let expected_ceil: IFix64<N9> = ORACLE
+      .spot
+      .checked_add(&max_delta)
+      .ok_or(CoreError::RebalanceDeviationArithmetic)?
+      .narrow()
+      .ok_or(CoreError::RebalancePriceConversion)?;
+    assert_eq!(curve.curve().y_min(), expected_floor);
+    assert_eq!(curve.curve().y_max(), expected_ceil);
+    Ok(())
   }
 
   #[test]

--- a/hylo-idl/idls/hylo_earn_pool.json
+++ b/hylo-idl/idls/hylo_earn_pool.json
@@ -1192,6 +1192,280 @@
       ]
     },
     {
+      "name": "pause_earn_pool",
+      "discriminator": [
+        161,
+        14,
+        172,
+        155,
+        237,
+        13,
+        37,
+        10
+      ],
+      "accounts": [
+        {
+          "name": "pause_authority",
+          "signer": true,
+          "relations": [
+            "hylo"
+          ]
+        },
+        {
+          "name": "hylo",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  104,
+                  121,
+                  108,
+                  111
+                ]
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                245,
+                187,
+                72,
+                160,
+                4,
+                116,
+                48,
+                134,
+                197,
+                164,
+                152,
+                189,
+                233,
+                219,
+                27,
+                124,
+                201,
+                65,
+                103,
+                243,
+                58,
+                82,
+                140,
+                90,
+                13,
+                150,
+                83,
+                40,
+                223,
+                158,
+                124,
+                33
+              ]
+            }
+          }
+        },
+        {
+          "name": "pool_config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  111,
+                  108,
+                  95,
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95,
+                  95,
+                  101,
+                  118,
+                  101,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [],
+      "returns": {
+        "defined": {
+          "name": "PauseEvent"
+        }
+      }
+    },
+    {
+      "name": "unpause_earn_pool",
+      "discriminator": [
+        114,
+        112,
+        75,
+        90,
+        222,
+        231,
+        255,
+        199
+      ],
+      "accounts": [
+        {
+          "name": "admin",
+          "signer": true,
+          "relations": [
+            "hylo"
+          ]
+        },
+        {
+          "name": "hylo",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  104,
+                  121,
+                  108,
+                  111
+                ]
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                245,
+                187,
+                72,
+                160,
+                4,
+                116,
+                48,
+                134,
+                197,
+                164,
+                152,
+                189,
+                233,
+                219,
+                27,
+                124,
+                201,
+                65,
+                103,
+                243,
+                58,
+                82,
+                140,
+                90,
+                13,
+                150,
+                83,
+                40,
+                223,
+                158,
+                124,
+                33
+              ]
+            }
+          }
+        },
+        {
+          "name": "pool_config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  111,
+                  108,
+                  95,
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95,
+                  95,
+                  101,
+                  118,
+                  101,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [],
+      "returns": {
+        "defined": {
+          "name": "UnpauseEvent"
+        }
+      }
+    },
+    {
       "name": "update_withdrawal_fee",
       "discriminator": [
         165,
@@ -2239,6 +2513,32 @@
       ]
     },
     {
+      "name": "PauseEvent",
+      "discriminator": [
+        32,
+        51,
+        61,
+        169,
+        156,
+        104,
+        130,
+        43
+      ]
+    },
+    {
+      "name": "UnpauseEvent",
+      "discriminator": [
+        134,
+        156,
+        8,
+        215,
+        185,
+        128,
+        192,
+        217
+      ]
+    },
+    {
       "name": "UpdateWithdrawalFeeEvent",
       "discriminator": [
         204,
@@ -2313,6 +2613,11 @@
       "code": 6006,
       "name": "LevercoinPoolNonzero",
       "msg": "Unable to deprecate levercoin pool due to nonzero balance."
+    },
+    {
+      "code": 6007,
+      "name": "EarnPoolPaused",
+      "msg": "Earn pool operations have been paused."
     }
   ],
   "types": [
@@ -2634,6 +2939,12 @@
       }
     },
     {
+      "name": "PauseEvent",
+      "type": {
+        "kind": "struct"
+      }
+    },
+    {
       "name": "PoolConfig",
       "type": {
         "kind": "struct",
@@ -2663,11 +2974,15 @@
             }
           },
           {
+            "name": "paused",
+            "type": "bool"
+          },
+          {
             "name": "_reserved",
             "type": {
               "array": [
                 "u8",
-                55
+                54
               ]
             }
           }
@@ -2804,6 +3119,12 @@
             "type": "i8"
           }
         ]
+      }
+    },
+    {
+      "name": "UnpauseEvent",
+      "type": {
+        "kind": "struct"
       }
     },
     {

--- a/hylo-idl/src/instruction_builders/earn_pool.rs
+++ b/hylo-idl/src/instruction_builders/earn_pool.rs
@@ -115,3 +115,35 @@ pub fn update_withdrawal_fee(
     data: args.data(),
   }
 }
+
+#[must_use]
+pub fn pause_earn_pool(pause_authority: Pubkey) -> Instruction {
+  let accounts = accounts::PauseEarnPool {
+    pause_authority,
+    hylo: pda::HYLO,
+    pool_config: pda::POOL_CONFIG,
+    event_authority: pda::EARN_POOL_EVENT_AUTHORITY,
+    program: earn_pool::ID,
+  };
+  Instruction {
+    program_id: earn_pool::ID,
+    accounts: accounts.to_account_metas(None),
+    data: args::PauseEarnPool {}.data(),
+  }
+}
+
+#[must_use]
+pub fn unpause_earn_pool(admin: Pubkey) -> Instruction {
+  let accounts = accounts::UnpauseEarnPool {
+    admin,
+    hylo: pda::HYLO,
+    pool_config: pda::POOL_CONFIG,
+    event_authority: pda::EARN_POOL_EVENT_AUTHORITY,
+    program: earn_pool::ID,
+  };
+  Instruction {
+    program_id: earn_pool::ID,
+    accounts: accounts.to_account_metas(None),
+    data: args::UnpauseEarnPool {}.data(),
+  }
+}

--- a/hylo-jupiter/src/account_metas.rs
+++ b/hylo-jupiter/src/account_metas.rs
@@ -5,8 +5,8 @@
 //! accounts.
 
 use anchor_lang::prelude::{Pubkey, ToAccountMetas};
-use hylo_idl::tokens::{TokenMint, HYUSD, SHYUSD, XSOL};
-use hylo_idl::{earn_pool, exchange};
+use hylo_idl::tokens::{TokenMint, HYUSD, SHYUSD, USDC, XSOL};
+use hylo_idl::{earn_pool, exchange, pda};
 use hylo_jupiter_amm_interface::{Swap, SwapAndAccountMetas};
 
 fn route_account_metas<A: ToAccountMetas>(
@@ -93,4 +93,190 @@ pub fn earn_pool_deposit(user: Pubkey) -> SwapAndAccountMetas {
 pub fn earn_pool_withdraw(user: Pubkey) -> SwapAndAccountMetas {
   let accounts = earn_pool::account_builders::withdraw(user);
   route_account_metas(SHYUSD::MINT, HYUSD::MINT, &accounts)
+}
+
+/// Swap one LST for another LST.
+#[must_use]
+pub fn swap_lst_to_lst(
+  user: Pubkey,
+  in_lst: Pubkey,
+  out_lst: Pubkey,
+) -> SwapAndAccountMetas {
+  let accounts =
+    exchange::account_builders::swap_lst_to_lst(user, in_lst, out_lst);
+  route_account_metas(in_lst, out_lst, &accounts)
+}
+
+/// Swap LST for USDC.
+#[must_use]
+pub fn swap_lst_to_usdc(
+  user: Pubkey,
+  lst_mint: Pubkey,
+  pool_state: Pubkey,
+) -> SwapAndAccountMetas {
+  let accounts =
+    exchange::account_builders::swap_lst_to_usdc(user, lst_mint, pool_state);
+  route_account_metas(lst_mint, USDC::MINT, &accounts)
+}
+
+/// Swap USDC for LST.
+#[must_use]
+pub fn swap_usdc_to_lst(
+  user: Pubkey,
+  lst_mint: Pubkey,
+  pool_state: Pubkey,
+) -> SwapAndAccountMetas {
+  let accounts =
+    exchange::account_builders::swap_usdc_to_lst(user, lst_mint, pool_state);
+  route_account_metas(USDC::MINT, lst_mint, &accounts)
+}
+
+/// Mint hyUSD from USDC.
+#[must_use]
+pub fn mint_stablecoin_usdc(user: Pubkey) -> SwapAndAccountMetas {
+  let accounts = exchange::account_builders::mint_stablecoin_usdc(user);
+  route_account_metas(USDC::MINT, HYUSD::MINT, &accounts)
+}
+
+/// Redeem hyUSD for USDC.
+#[must_use]
+pub fn redeem_stablecoin_usdc(user: Pubkey) -> SwapAndAccountMetas {
+  let accounts = exchange::account_builders::redeem_stablecoin_usdc(user);
+  route_account_metas(HYUSD::MINT, USDC::MINT, &accounts)
+}
+
+/// Swap exo collateral for USDC.
+#[must_use]
+pub fn swap_exo_to_usdc(
+  user: Pubkey,
+  collateral_mint: Pubkey,
+  collateral_usd_pyth_feed: Pubkey,
+) -> SwapAndAccountMetas {
+  let accounts = exchange::account_builders::swap_exo_to_usdc(
+    user,
+    collateral_mint,
+    collateral_usd_pyth_feed,
+  );
+  route_account_metas(collateral_mint, USDC::MINT, &accounts)
+}
+
+/// Swap USDC for exo collateral.
+#[must_use]
+pub fn swap_usdc_to_exo(
+  user: Pubkey,
+  collateral_mint: Pubkey,
+  collateral_usd_pyth_feed: Pubkey,
+) -> SwapAndAccountMetas {
+  let accounts = exchange::account_builders::swap_usdc_to_exo(
+    user,
+    collateral_mint,
+    collateral_usd_pyth_feed,
+  );
+  route_account_metas(USDC::MINT, collateral_mint, &accounts)
+}
+
+/// Mint hyUSD from exo collateral.
+#[must_use]
+pub fn mint_stablecoin_exo(
+  user: Pubkey,
+  collateral_mint: Pubkey,
+  collateral_usd_pyth_feed: Pubkey,
+) -> SwapAndAccountMetas {
+  let accounts = exchange::account_builders::mint_stablecoin_exo(
+    user,
+    collateral_mint,
+    collateral_usd_pyth_feed,
+  );
+  route_account_metas(collateral_mint, HYUSD::MINT, &accounts)
+}
+
+/// Redeem hyUSD for exo collateral.
+#[must_use]
+pub fn redeem_stablecoin_exo(
+  user: Pubkey,
+  collateral_mint: Pubkey,
+  collateral_usd_pyth_feed: Pubkey,
+) -> SwapAndAccountMetas {
+  let accounts = exchange::account_builders::redeem_stablecoin_exo(
+    user,
+    collateral_mint,
+    collateral_usd_pyth_feed,
+  );
+  route_account_metas(HYUSD::MINT, collateral_mint, &accounts)
+}
+
+/// Mint exo levercoin from exo collateral.
+#[must_use]
+pub fn mint_levercoin_exo(
+  user: Pubkey,
+  collateral_mint: Pubkey,
+  collateral_usd_pyth_feed: Pubkey,
+) -> SwapAndAccountMetas {
+  let accounts = exchange::account_builders::mint_levercoin_exo(
+    user,
+    collateral_mint,
+    collateral_usd_pyth_feed,
+  );
+  route_account_metas(
+    collateral_mint,
+    pda::exo_levercoin_mint(collateral_mint),
+    &accounts,
+  )
+}
+
+/// Redeem exo levercoin for exo collateral.
+#[must_use]
+pub fn redeem_levercoin_exo(
+  user: Pubkey,
+  collateral_mint: Pubkey,
+  collateral_usd_pyth_feed: Pubkey,
+) -> SwapAndAccountMetas {
+  let accounts = exchange::account_builders::redeem_levercoin_exo(
+    user,
+    collateral_mint,
+    collateral_usd_pyth_feed,
+  );
+  route_account_metas(
+    pda::exo_levercoin_mint(collateral_mint),
+    collateral_mint,
+    &accounts,
+  )
+}
+
+/// Convert hyUSD to exo levercoin.
+#[must_use]
+pub fn convert_stable_to_lever_exo(
+  user: Pubkey,
+  collateral_mint: Pubkey,
+  collateral_usd_pyth_feed: Pubkey,
+) -> SwapAndAccountMetas {
+  let accounts = exchange::account_builders::convert_stable_to_lever_exo(
+    user,
+    collateral_mint,
+    collateral_usd_pyth_feed,
+  );
+  route_account_metas(
+    HYUSD::MINT,
+    pda::exo_levercoin_mint(collateral_mint),
+    &accounts,
+  )
+}
+
+/// Convert exo levercoin to hyUSD.
+#[must_use]
+pub fn convert_lever_to_stable_exo(
+  user: Pubkey,
+  collateral_mint: Pubkey,
+  collateral_usd_pyth_feed: Pubkey,
+) -> SwapAndAccountMetas {
+  let accounts = exchange::account_builders::convert_lever_to_stable_exo(
+    user,
+    collateral_mint,
+    collateral_usd_pyth_feed,
+  );
+  route_account_metas(
+    pda::exo_levercoin_mint(collateral_mint),
+    HYUSD::MINT,
+    &accounts,
+  )
 }

--- a/hylo-jupiter/src/jupiter.rs
+++ b/hylo-jupiter/src/jupiter.rs
@@ -9,7 +9,8 @@ use hylo_core::exchange_context::ExoExchangeContext;
 use hylo_core::idl::earn_pool::accounts::PoolConfig;
 use hylo_core::idl::exchange::accounts::{ExoPair, Hylo, LstHeader, UsdcPair};
 use hylo_core::idl::tokens::{
-  StakePool, TokenMint, CBBTC, HYLOSOL, HYUSD, JITOSOL, SHYUSD, XSOL,
+  StakePool, TokenMint, CBBTC, HYLOSOL, HYUSD, JITOSOL, SHYUSD, USDC, XBTC,
+  XSOL,
 };
 use hylo_core::idl::{earn_pool, exchange, pda};
 use hylo_core::lst::stake_pool::SplStakePool;
@@ -318,6 +319,370 @@ impl PairConfig<HYUSD, SHYUSD> for HyloJupiterPair<HYUSD, SHYUSD> {
   }
 }
 
+impl PairConfig<JITOSOL, HYLOSOL> for HyloJupiterPair<JITOSOL, HYLOSOL> {
+  fn program_id() -> Pubkey {
+    exchange::ID
+  }
+  fn label() -> &'static str {
+    "Hylo JITOSOL<->HYLOSOL"
+  }
+  fn key() -> Pubkey {
+    pda::HYLO
+  }
+
+  fn quote(
+    state: &ProtocolState<ClockRef>,
+    amount: u64,
+    input_mint: Pubkey,
+    output_mint: Pubkey,
+  ) -> Result<Quote> {
+    match (input_mint, output_mint) {
+      (JITOSOL::MINT, HYLOSOL::MINT) => {
+        quote::<JITOSOL, HYLOSOL>(state, amount)
+      }
+      (HYLOSOL::MINT, JITOSOL::MINT) => {
+        quote::<HYLOSOL, JITOSOL>(state, amount)
+      }
+      _ => Err(anyhow!("Invalid mint pair")),
+    }
+  }
+
+  fn build_account_metas(
+    user: Pubkey,
+    input_mint: Pubkey,
+    output_mint: Pubkey,
+  ) -> Result<SwapAndAccountMetas> {
+    match (input_mint, output_mint) {
+      (JITOSOL::MINT, HYLOSOL::MINT) => Ok(account_metas::swap_lst_to_lst(
+        user,
+        JITOSOL::MINT,
+        HYLOSOL::MINT,
+      )),
+      (HYLOSOL::MINT, JITOSOL::MINT) => Ok(account_metas::swap_lst_to_lst(
+        user,
+        HYLOSOL::MINT,
+        JITOSOL::MINT,
+      )),
+      _ => Err(anyhow!("Invalid mint pair")),
+    }
+  }
+}
+
+impl PairConfig<JITOSOL, USDC> for HyloJupiterPair<JITOSOL, USDC> {
+  fn program_id() -> Pubkey {
+    exchange::ID
+  }
+  fn label() -> &'static str {
+    "Hylo JITOSOL<->USDC"
+  }
+  fn key() -> Pubkey {
+    pda::HYLO
+  }
+
+  fn quote(
+    state: &ProtocolState<ClockRef>,
+    amount: u64,
+    input_mint: Pubkey,
+    output_mint: Pubkey,
+  ) -> Result<Quote> {
+    match (input_mint, output_mint) {
+      (JITOSOL::MINT, USDC::MINT) => quote::<JITOSOL, USDC>(state, amount),
+      (USDC::MINT, JITOSOL::MINT) => quote::<USDC, JITOSOL>(state, amount),
+      _ => Err(anyhow!("Invalid mint pair")),
+    }
+  }
+
+  fn build_account_metas(
+    user: Pubkey,
+    input_mint: Pubkey,
+    output_mint: Pubkey,
+  ) -> Result<SwapAndAccountMetas> {
+    match (input_mint, output_mint) {
+      (JITOSOL::MINT, USDC::MINT) => Ok(account_metas::swap_lst_to_usdc(
+        user,
+        JITOSOL::MINT,
+        JITOSOL::POOL_STATE,
+      )),
+      (USDC::MINT, JITOSOL::MINT) => Ok(account_metas::swap_usdc_to_lst(
+        user,
+        JITOSOL::MINT,
+        JITOSOL::POOL_STATE,
+      )),
+      _ => Err(anyhow!("Invalid mint pair")),
+    }
+  }
+}
+
+impl PairConfig<HYLOSOL, USDC> for HyloJupiterPair<HYLOSOL, USDC> {
+  fn program_id() -> Pubkey {
+    exchange::ID
+  }
+  fn label() -> &'static str {
+    "Hylo HYLOSOL<->USDC"
+  }
+  fn key() -> Pubkey {
+    pda::HYLO
+  }
+
+  fn quote(
+    state: &ProtocolState<ClockRef>,
+    amount: u64,
+    input_mint: Pubkey,
+    output_mint: Pubkey,
+  ) -> Result<Quote> {
+    match (input_mint, output_mint) {
+      (HYLOSOL::MINT, USDC::MINT) => quote::<HYLOSOL, USDC>(state, amount),
+      (USDC::MINT, HYLOSOL::MINT) => quote::<USDC, HYLOSOL>(state, amount),
+      _ => Err(anyhow!("Invalid mint pair")),
+    }
+  }
+
+  fn build_account_metas(
+    user: Pubkey,
+    input_mint: Pubkey,
+    output_mint: Pubkey,
+  ) -> Result<SwapAndAccountMetas> {
+    match (input_mint, output_mint) {
+      (HYLOSOL::MINT, USDC::MINT) => Ok(account_metas::swap_lst_to_usdc(
+        user,
+        HYLOSOL::MINT,
+        HYLOSOL::POOL_STATE,
+      )),
+      (USDC::MINT, HYLOSOL::MINT) => Ok(account_metas::swap_usdc_to_lst(
+        user,
+        HYLOSOL::MINT,
+        HYLOSOL::POOL_STATE,
+      )),
+      _ => Err(anyhow!("Invalid mint pair")),
+    }
+  }
+}
+
+impl PairConfig<USDC, HYUSD> for HyloJupiterPair<USDC, HYUSD> {
+  fn program_id() -> Pubkey {
+    exchange::ID
+  }
+  fn label() -> &'static str {
+    "Hylo USDC<->HYUSD"
+  }
+  fn key() -> Pubkey {
+    pda::HYLO
+  }
+
+  fn quote(
+    state: &ProtocolState<ClockRef>,
+    amount: u64,
+    input_mint: Pubkey,
+    output_mint: Pubkey,
+  ) -> Result<Quote> {
+    match (input_mint, output_mint) {
+      (USDC::MINT, HYUSD::MINT) => quote::<USDC, HYUSD>(state, amount),
+      (HYUSD::MINT, USDC::MINT) => quote::<HYUSD, USDC>(state, amount),
+      _ => Err(anyhow!("Invalid mint pair")),
+    }
+  }
+
+  fn build_account_metas(
+    user: Pubkey,
+    input_mint: Pubkey,
+    output_mint: Pubkey,
+  ) -> Result<SwapAndAccountMetas> {
+    match (input_mint, output_mint) {
+      (USDC::MINT, HYUSD::MINT) => {
+        Ok(account_metas::mint_stablecoin_usdc(user))
+      }
+      (HYUSD::MINT, USDC::MINT) => {
+        Ok(account_metas::redeem_stablecoin_usdc(user))
+      }
+      _ => Err(anyhow!("Invalid mint pair")),
+    }
+  }
+}
+
+impl PairConfig<CBBTC, USDC> for HyloJupiterPair<CBBTC, USDC> {
+  fn program_id() -> Pubkey {
+    exchange::ID
+  }
+  fn label() -> &'static str {
+    "Hylo CBBTC<->USDC"
+  }
+  fn key() -> Pubkey {
+    pda::HYLO
+  }
+
+  fn quote(
+    state: &ProtocolState<ClockRef>,
+    amount: u64,
+    input_mint: Pubkey,
+    output_mint: Pubkey,
+  ) -> Result<Quote> {
+    match (input_mint, output_mint) {
+      (CBBTC::MINT, USDC::MINT) => quote::<CBBTC, USDC>(state, amount),
+      (USDC::MINT, CBBTC::MINT) => quote::<USDC, CBBTC>(state, amount),
+      _ => Err(anyhow!("Invalid mint pair")),
+    }
+  }
+
+  fn build_account_metas(
+    user: Pubkey,
+    input_mint: Pubkey,
+    output_mint: Pubkey,
+  ) -> Result<SwapAndAccountMetas> {
+    match (input_mint, output_mint) {
+      (CBBTC::MINT, USDC::MINT) => Ok(account_metas::swap_exo_to_usdc(
+        user,
+        CBBTC::MINT,
+        pda::BTC_USD_PYTH_FEED,
+      )),
+      (USDC::MINT, CBBTC::MINT) => Ok(account_metas::swap_usdc_to_exo(
+        user,
+        CBBTC::MINT,
+        pda::BTC_USD_PYTH_FEED,
+      )),
+      _ => Err(anyhow!("Invalid mint pair")),
+    }
+  }
+}
+
+impl PairConfig<CBBTC, HYUSD> for HyloJupiterPair<CBBTC, HYUSD> {
+  fn program_id() -> Pubkey {
+    exchange::ID
+  }
+  fn label() -> &'static str {
+    "Hylo CBBTC<->HYUSD"
+  }
+  fn key() -> Pubkey {
+    pda::HYLO
+  }
+
+  fn quote(
+    state: &ProtocolState<ClockRef>,
+    amount: u64,
+    input_mint: Pubkey,
+    output_mint: Pubkey,
+  ) -> Result<Quote> {
+    match (input_mint, output_mint) {
+      (CBBTC::MINT, HYUSD::MINT) => quote::<CBBTC, HYUSD>(state, amount),
+      (HYUSD::MINT, CBBTC::MINT) => quote::<HYUSD, CBBTC>(state, amount),
+      _ => Err(anyhow!("Invalid mint pair")),
+    }
+  }
+
+  fn build_account_metas(
+    user: Pubkey,
+    input_mint: Pubkey,
+    output_mint: Pubkey,
+  ) -> Result<SwapAndAccountMetas> {
+    match (input_mint, output_mint) {
+      (CBBTC::MINT, HYUSD::MINT) => Ok(account_metas::mint_stablecoin_exo(
+        user,
+        CBBTC::MINT,
+        pda::BTC_USD_PYTH_FEED,
+      )),
+      (HYUSD::MINT, CBBTC::MINT) => Ok(account_metas::redeem_stablecoin_exo(
+        user,
+        CBBTC::MINT,
+        pda::BTC_USD_PYTH_FEED,
+      )),
+      _ => Err(anyhow!("Invalid mint pair")),
+    }
+  }
+}
+
+impl PairConfig<CBBTC, XBTC> for HyloJupiterPair<CBBTC, XBTC> {
+  fn program_id() -> Pubkey {
+    exchange::ID
+  }
+  fn label() -> &'static str {
+    "Hylo CBBTC<->XBTC"
+  }
+  fn key() -> Pubkey {
+    pda::HYLO
+  }
+
+  fn quote(
+    state: &ProtocolState<ClockRef>,
+    amount: u64,
+    input_mint: Pubkey,
+    output_mint: Pubkey,
+  ) -> Result<Quote> {
+    match (input_mint, output_mint) {
+      (CBBTC::MINT, XBTC::MINT) => quote::<CBBTC, XBTC>(state, amount),
+      (XBTC::MINT, CBBTC::MINT) => quote::<XBTC, CBBTC>(state, amount),
+      _ => Err(anyhow!("Invalid mint pair")),
+    }
+  }
+
+  fn build_account_metas(
+    user: Pubkey,
+    input_mint: Pubkey,
+    output_mint: Pubkey,
+  ) -> Result<SwapAndAccountMetas> {
+    match (input_mint, output_mint) {
+      (CBBTC::MINT, XBTC::MINT) => Ok(account_metas::mint_levercoin_exo(
+        user,
+        CBBTC::MINT,
+        pda::BTC_USD_PYTH_FEED,
+      )),
+      (XBTC::MINT, CBBTC::MINT) => Ok(account_metas::redeem_levercoin_exo(
+        user,
+        CBBTC::MINT,
+        pda::BTC_USD_PYTH_FEED,
+      )),
+      _ => Err(anyhow!("Invalid mint pair")),
+    }
+  }
+}
+
+impl PairConfig<HYUSD, XBTC> for HyloJupiterPair<HYUSD, XBTC> {
+  fn program_id() -> Pubkey {
+    exchange::ID
+  }
+  fn label() -> &'static str {
+    "Hylo HYUSD<->XBTC"
+  }
+  fn key() -> Pubkey {
+    pda::HYLO
+  }
+
+  fn quote(
+    state: &ProtocolState<ClockRef>,
+    amount: u64,
+    input_mint: Pubkey,
+    output_mint: Pubkey,
+  ) -> Result<Quote> {
+    match (input_mint, output_mint) {
+      (HYUSD::MINT, XBTC::MINT) => quote::<HYUSD, XBTC>(state, amount),
+      (XBTC::MINT, HYUSD::MINT) => quote::<XBTC, HYUSD>(state, amount),
+      _ => Err(anyhow!("Invalid mint pair")),
+    }
+  }
+
+  fn build_account_metas(
+    user: Pubkey,
+    input_mint: Pubkey,
+    output_mint: Pubkey,
+  ) -> Result<SwapAndAccountMetas> {
+    match (input_mint, output_mint) {
+      (HYUSD::MINT, XBTC::MINT) => {
+        Ok(account_metas::convert_stable_to_lever_exo(
+          user,
+          CBBTC::MINT,
+          pda::BTC_USD_PYTH_FEED,
+        ))
+      }
+      (XBTC::MINT, HYUSD::MINT) => {
+        Ok(account_metas::convert_lever_to_stable_exo(
+          user,
+          CBBTC::MINT,
+          pda::BTC_USD_PYTH_FEED,
+        ))
+      }
+      _ => Err(anyhow!("Invalid mint pair")),
+    }
+  }
+}
+
 impl<IN, OUT> Amm for HyloJupiterPair<IN, OUT>
 where
   IN: TokenMint + 'static,
@@ -361,6 +726,8 @@ where
       XSOL::MINT,
       pda::lst_header(JITOSOL::MINT),
       pda::lst_header(HYLOSOL::MINT),
+      JITOSOL::POOL_STATE,
+      HYLOSOL::POOL_STATE,
       SOL_USD.address,
       SHYUSD::MINT,
       pda::HYUSD_POOL,
@@ -515,7 +882,8 @@ mod tests {
   use anchor_lang::pubkey;
   use fix::prelude::*;
   use hylo_clients::prelude::{
-    RouterArgs, TransactionSyntax, HYUSD, JITOSOL, SHYUSD, XSOL,
+    RouterArgs, TransactionSyntax, CBBTC, HYLOSOL, HYUSD, JITOSOL, SHYUSD,
+    USDC, XBTC, XSOL,
   };
   use hylo_clients::program_client::ProgramClient;
   use hylo_clients::util::build_test_router_client;
@@ -523,9 +891,14 @@ mod tests {
     UserDepositEvent, UserWithdrawEvent,
   };
   use hylo_core::idl::exchange::events::{
-    ConvertLeverToStableLstEvent, ConvertStableToLeverLstEvent,
-    MintLevercoinLstEvent, MintStablecoinLstEvent, RedeemLevercoinLstEvent,
-    RedeemStablecoinLstEvent,
+    ConvertLeverToStableExoEvent, ConvertLeverToStableLstEvent,
+    ConvertStableToLeverExoEvent, ConvertStableToLeverLstEvent,
+    MintLevercoinExoEvent, MintLevercoinLstEvent, MintStablecoinExoEvent,
+    MintStablecoinLstEvent, MintStablecoinUsdcEvent, RedeemLevercoinExoEvent,
+    RedeemLevercoinLstEvent, RedeemStablecoinExoEvent,
+    RedeemStablecoinLstEvent, RedeemStablecoinUsdcEvent, SwapExoToUsdcEvent,
+    SwapLstToLstEvent, SwapLstToUsdcEvent, SwapUsdcToExoEvent,
+    SwapUsdcToLstEvent,
   };
   use hylo_jupiter_amm_interface::{KeyedAccount, SwapMode};
   use rust_decimal::Decimal;
@@ -837,10 +1210,572 @@ mod tests {
     assert_eq!(sim.lp_token_minted.bits, quote.out_amount);
 
     // Fees extracted
-    assert_eq!(0, quote.fee_amount);
+    assert_eq!(u64::MIN, quote.fee_amount);
 
     // Fee percentage
     assert_eq!(Decimal::ZERO, quote.fee_pct);
+    Ok(())
+  }
+
+  #[tokio::test]
+  async fn jitosol_to_hylosol_swap_check() -> Result<()> {
+    let amount_in = UFix64::<N9>::one();
+    let quote_params = QuoteParams {
+      amount: amount_in.bits,
+      input_mint: JITOSOL::MINT,
+      output_mint: HYLOSOL::MINT,
+      swap_mode: SwapMode::ExactIn,
+    };
+    let jup = build_jupiter_pair::<JITOSOL, HYLOSOL>().await?;
+    let hylo = build_test_router_client()?;
+    let args = hylo
+      .build_transaction_data::<JITOSOL, HYLOSOL>(RouterArgs {
+        amount: amount_in.bits,
+        user: TESTER,
+        slippage_config: None,
+      })
+      .await?;
+    let tx = hylo.build_simulation_transaction(&TESTER, &args).await?;
+    let sim = hylo
+      .simulate_transaction_return::<SwapLstToLstEvent>(&tx)
+      .await?;
+    let quote = jup.quote(&quote_params)?;
+    assert_eq!(sim.lst_a_in.bits, quote.in_amount);
+    assert_eq!(sim.lst_b_out.bits, quote.out_amount);
+    assert_eq!(sim.lst_a_fees_extracted.bits, quote.fee_amount);
+    let fees: UFix64<N9> = sim.lst_a_fees_extracted.try_into()?;
+    let total_in: UFix64<N9> = sim.lst_a_in.try_into()?;
+    let fee_pct = fee_pct_decimal(fees, total_in)?;
+    assert_eq!(fee_pct, quote.fee_pct);
+    Ok(())
+  }
+
+  #[tokio::test]
+  async fn hylosol_to_jitosol_swap_check() -> Result<()> {
+    let amount_in = UFix64::<N9>::one();
+    let quote_params = QuoteParams {
+      amount: amount_in.bits,
+      input_mint: HYLOSOL::MINT,
+      output_mint: JITOSOL::MINT,
+      swap_mode: SwapMode::ExactIn,
+    };
+    let jup = build_jupiter_pair::<JITOSOL, HYLOSOL>().await?;
+    let hylo = build_test_router_client()?;
+    let args = hylo
+      .build_transaction_data::<HYLOSOL, JITOSOL>(RouterArgs {
+        amount: amount_in.bits,
+        user: TESTER,
+        slippage_config: None,
+      })
+      .await?;
+    let tx = hylo.build_simulation_transaction(&TESTER, &args).await?;
+    let sim = hylo
+      .simulate_transaction_return::<SwapLstToLstEvent>(&tx)
+      .await?;
+    let quote = jup.quote(&quote_params)?;
+    assert_eq!(sim.lst_a_in.bits, quote.in_amount);
+    assert_eq!(sim.lst_b_out.bits, quote.out_amount);
+    assert_eq!(sim.lst_a_fees_extracted.bits, quote.fee_amount);
+    let fees: UFix64<N9> = sim.lst_a_fees_extracted.try_into()?;
+    let total_in: UFix64<N9> = sim.lst_a_in.try_into()?;
+    let fee_pct = fee_pct_decimal(fees, total_in)?;
+    assert_eq!(fee_pct, quote.fee_pct);
+    Ok(())
+  }
+
+  #[tokio::test]
+  async fn jitosol_to_usdc_swap_check() -> Result<()> {
+    let amount_in = UFix64::<N9>::one();
+    let quote_params = QuoteParams {
+      amount: amount_in.bits,
+      input_mint: JITOSOL::MINT,
+      output_mint: USDC::MINT,
+      swap_mode: SwapMode::ExactIn,
+    };
+    let jup = build_jupiter_pair::<JITOSOL, USDC>().await?;
+    let hylo = build_test_router_client()?;
+    let args = hylo
+      .build_transaction_data::<JITOSOL, USDC>(RouterArgs {
+        amount: amount_in.bits,
+        user: TESTER,
+        slippage_config: None,
+      })
+      .await?;
+    let tx = hylo.build_simulation_transaction(&TESTER, &args).await?;
+    let sim = hylo
+      .simulate_transaction_return::<SwapLstToUsdcEvent>(&tx)
+      .await?;
+    let quote = jup.quote(&quote_params)?;
+    assert_eq!(sim.lst_deposited.bits, quote.in_amount);
+    let usdc_withdrawn: UFix64<N9> = sim.usdc_withdrawn.try_into()?;
+    let out: UFix64<N6> = usdc_withdrawn.checked_convert().context("N9->N6")?;
+    assert_eq!(out.bits, quote.out_amount);
+    assert_eq!(u64::MIN, quote.fee_amount);
+    assert_eq!(Decimal::ZERO, quote.fee_pct);
+    Ok(())
+  }
+
+  #[tokio::test]
+  async fn usdc_to_jitosol_swap_check() -> Result<()> {
+    let amount_in = UFix64::<N6>::one();
+    let quote_params = QuoteParams {
+      amount: amount_in.bits,
+      input_mint: USDC::MINT,
+      output_mint: JITOSOL::MINT,
+      swap_mode: SwapMode::ExactIn,
+    };
+    let jup = build_jupiter_pair::<JITOSOL, USDC>().await?;
+    let hylo = build_test_router_client()?;
+    let args = hylo
+      .build_transaction_data::<USDC, JITOSOL>(RouterArgs {
+        amount: amount_in.bits,
+        user: TESTER,
+        slippage_config: None,
+      })
+      .await?;
+    let tx = hylo.build_simulation_transaction(&TESTER, &args).await?;
+    let sim = hylo
+      .simulate_transaction_return::<SwapUsdcToLstEvent>(&tx)
+      .await?;
+    let quote = jup.quote(&quote_params)?;
+    let usdc_deposited: UFix64<N9> = sim.usdc_deposited.try_into()?;
+    let in_amt: UFix64<N6> =
+      usdc_deposited.checked_convert().context("N9->N6")?;
+    assert_eq!(in_amt.bits, quote.in_amount);
+    assert_eq!(sim.lst_withdrawn.bits, quote.out_amount);
+    assert_eq!(u64::MIN, quote.fee_amount);
+    assert_eq!(Decimal::ZERO, quote.fee_pct);
+    Ok(())
+  }
+
+  #[tokio::test]
+  async fn hylosol_to_usdc_swap_check() -> Result<()> {
+    let amount_in = UFix64::<N9>::one();
+    let quote_params = QuoteParams {
+      amount: amount_in.bits,
+      input_mint: HYLOSOL::MINT,
+      output_mint: USDC::MINT,
+      swap_mode: SwapMode::ExactIn,
+    };
+    let jup = build_jupiter_pair::<HYLOSOL, USDC>().await?;
+    let hylo = build_test_router_client()?;
+    let args = hylo
+      .build_transaction_data::<HYLOSOL, USDC>(RouterArgs {
+        amount: amount_in.bits,
+        user: TESTER,
+        slippage_config: None,
+      })
+      .await?;
+    let tx = hylo.build_simulation_transaction(&TESTER, &args).await?;
+    let sim = hylo
+      .simulate_transaction_return::<SwapLstToUsdcEvent>(&tx)
+      .await?;
+    let quote = jup.quote(&quote_params)?;
+    assert_eq!(sim.lst_deposited.bits, quote.in_amount);
+    let usdc_withdrawn: UFix64<N9> = sim.usdc_withdrawn.try_into()?;
+    let out: UFix64<N6> = usdc_withdrawn.checked_convert().context("N9->N6")?;
+    assert_eq!(out.bits, quote.out_amount);
+    assert_eq!(u64::MIN, quote.fee_amount);
+    assert_eq!(Decimal::ZERO, quote.fee_pct);
+    Ok(())
+  }
+
+  #[tokio::test]
+  async fn usdc_to_hylosol_swap_check() -> Result<()> {
+    let amount_in = UFix64::<N6>::one();
+    let quote_params = QuoteParams {
+      amount: amount_in.bits,
+      input_mint: USDC::MINT,
+      output_mint: HYLOSOL::MINT,
+      swap_mode: SwapMode::ExactIn,
+    };
+    let jup = build_jupiter_pair::<HYLOSOL, USDC>().await?;
+    let hylo = build_test_router_client()?;
+    let args = hylo
+      .build_transaction_data::<USDC, HYLOSOL>(RouterArgs {
+        amount: amount_in.bits,
+        user: TESTER,
+        slippage_config: None,
+      })
+      .await?;
+    let tx = hylo.build_simulation_transaction(&TESTER, &args).await?;
+    let sim = hylo
+      .simulate_transaction_return::<SwapUsdcToLstEvent>(&tx)
+      .await?;
+    let quote = jup.quote(&quote_params)?;
+    let usdc_deposited: UFix64<N9> = sim.usdc_deposited.try_into()?;
+    let in_amt: UFix64<N6> =
+      usdc_deposited.checked_convert().context("N9->N6")?;
+    assert_eq!(in_amt.bits, quote.in_amount);
+    assert_eq!(sim.lst_withdrawn.bits, quote.out_amount);
+    assert_eq!(u64::MIN, quote.fee_amount);
+    assert_eq!(Decimal::ZERO, quote.fee_pct);
+    Ok(())
+  }
+
+  #[tokio::test]
+  async fn usdc_to_hyusd_mint_check() -> Result<()> {
+    let amount_usdc = UFix64::<N6>::one();
+    let quote_params = QuoteParams {
+      amount: amount_usdc.bits,
+      input_mint: USDC::MINT,
+      output_mint: HYUSD::MINT,
+      swap_mode: SwapMode::ExactIn,
+    };
+    let jup = build_jupiter_pair::<USDC, HYUSD>().await?;
+    let hylo = build_test_router_client()?;
+    let args = hylo
+      .build_transaction_data::<USDC, HYUSD>(RouterArgs {
+        amount: amount_usdc.bits,
+        user: TESTER,
+        slippage_config: None,
+      })
+      .await?;
+    let tx = hylo.build_simulation_transaction(&TESTER, &args).await?;
+    let sim = hylo
+      .simulate_transaction_return::<MintStablecoinUsdcEvent>(&tx)
+      .await?;
+    let quote = jup.quote(&quote_params)?;
+    let usdc_deposited: UFix64<N9> = sim.usdc_deposited.try_into()?;
+    let usdc_fees: UFix64<N9> = sim.usdc_fees.try_into()?;
+    let fee_base = usdc_deposited
+      .checked_add(&usdc_fees)
+      .ok_or(anyhow!("fee_base"))?;
+    let in_amt: UFix64<N6> = fee_base.checked_convert().context("N9->N6")?;
+    assert_eq!(in_amt.bits, quote.in_amount);
+    assert_eq!(sim.stablecoin_minted.bits, quote.out_amount);
+    assert_eq!(sim.usdc_fees.bits, quote.fee_amount);
+    let fee_pct = fee_pct_decimal(usdc_fees, fee_base)?;
+    assert_eq!(fee_pct, quote.fee_pct);
+    Ok(())
+  }
+
+  #[tokio::test]
+  async fn hyusd_to_usdc_redeem_check() -> Result<()> {
+    let amount_hyusd = UFix64::<N6>::one();
+    let quote_params = QuoteParams {
+      amount: amount_hyusd.bits,
+      input_mint: HYUSD::MINT,
+      output_mint: USDC::MINT,
+      swap_mode: SwapMode::ExactIn,
+    };
+    let jup = build_jupiter_pair::<USDC, HYUSD>().await?;
+    let hylo = build_test_router_client()?;
+    let args = hylo
+      .build_transaction_data::<HYUSD, USDC>(RouterArgs {
+        amount: amount_hyusd.bits,
+        user: TESTER,
+        slippage_config: None,
+      })
+      .await?;
+    let tx = hylo.build_simulation_transaction(&TESTER, &args).await?;
+    let sim = hylo
+      .simulate_transaction_return::<RedeemStablecoinUsdcEvent>(&tx)
+      .await?;
+    let quote = jup.quote(&quote_params)?;
+    let burned: UFix64<N6> = sim.stablecoin_burned.try_into()?;
+    let fees: UFix64<N6> = sim.stablecoin_fees.try_into()?;
+    let fee_base = burned.checked_add(&fees).ok_or(anyhow!("fee_base"))?;
+    assert_eq!(fee_base.bits, quote.in_amount);
+    assert_eq!(sim.usdc_withdrawn.bits, quote.out_amount);
+    assert_eq!(sim.stablecoin_fees.bits, quote.fee_amount);
+    let fee_pct = fee_pct_decimal(fees, fee_base)?;
+    assert_eq!(fee_pct, quote.fee_pct);
+    Ok(())
+  }
+
+  #[tokio::test]
+  async fn cbbtc_to_usdc_swap_check() -> Result<()> {
+    let amount_cbbtc = UFix64::<N8>::one();
+    let quote_params = QuoteParams {
+      amount: amount_cbbtc.bits,
+      input_mint: CBBTC::MINT,
+      output_mint: USDC::MINT,
+      swap_mode: SwapMode::ExactIn,
+    };
+    let jup = build_jupiter_pair::<CBBTC, USDC>().await?;
+    let hylo = build_test_router_client()?;
+    let args = hylo
+      .build_transaction_data::<CBBTC, USDC>(RouterArgs {
+        amount: amount_cbbtc.bits,
+        user: TESTER,
+        slippage_config: None,
+      })
+      .await?;
+    let tx = hylo.build_simulation_transaction(&TESTER, &args).await?;
+    let sim = hylo
+      .simulate_transaction_return::<SwapExoToUsdcEvent>(&tx)
+      .await?;
+    let quote = jup.quote(&quote_params)?;
+    let collateral_deposited: UFix64<N9> =
+      sim.collateral_deposited.try_into()?;
+    let in_amt: UFix64<N8> =
+      collateral_deposited.checked_convert().context("N9->N8")?;
+    assert_eq!(in_amt.bits, quote.in_amount);
+    let usdc_withdrawn: UFix64<N9> = sim.usdc_withdrawn.try_into()?;
+    let out: UFix64<N6> = usdc_withdrawn.checked_convert().context("N9->N6")?;
+    assert_eq!(out.bits, quote.out_amount);
+    assert_eq!(u64::MIN, quote.fee_amount);
+    assert_eq!(Decimal::ZERO, quote.fee_pct);
+    Ok(())
+  }
+
+  #[tokio::test]
+  async fn usdc_to_cbbtc_swap_check() -> Result<()> {
+    let amount_usdc = UFix64::<N6>::one();
+    let quote_params = QuoteParams {
+      amount: amount_usdc.bits,
+      input_mint: USDC::MINT,
+      output_mint: CBBTC::MINT,
+      swap_mode: SwapMode::ExactIn,
+    };
+    let jup = build_jupiter_pair::<CBBTC, USDC>().await?;
+    let hylo = build_test_router_client()?;
+    let args = hylo
+      .build_transaction_data::<USDC, CBBTC>(RouterArgs {
+        amount: amount_usdc.bits,
+        user: TESTER,
+        slippage_config: None,
+      })
+      .await?;
+    let tx = hylo.build_simulation_transaction(&TESTER, &args).await?;
+    let sim = hylo
+      .simulate_transaction_return::<SwapUsdcToExoEvent>(&tx)
+      .await?;
+    let quote = jup.quote(&quote_params)?;
+    let usdc_deposited: UFix64<N9> = sim.usdc_deposited.try_into()?;
+    let in_amt: UFix64<N6> =
+      usdc_deposited.checked_convert().context("N9->N6")?;
+    assert_eq!(in_amt.bits, quote.in_amount);
+    let collateral_withdrawn: UFix64<N9> =
+      sim.collateral_withdrawn.try_into()?;
+    let out: UFix64<N8> =
+      collateral_withdrawn.checked_convert().context("N9->N8")?;
+    assert_eq!(out.bits, quote.out_amount);
+    assert_eq!(u64::MIN, quote.fee_amount);
+    assert_eq!(Decimal::ZERO, quote.fee_pct);
+    Ok(())
+  }
+
+  #[tokio::test]
+  async fn cbbtc_to_hyusd_mint_check() -> Result<()> {
+    let amount_cbbtc = UFix64::<N8>::one();
+    let quote_params = QuoteParams {
+      amount: amount_cbbtc.bits,
+      input_mint: CBBTC::MINT,
+      output_mint: HYUSD::MINT,
+      swap_mode: SwapMode::ExactIn,
+    };
+    let jup = build_jupiter_pair::<CBBTC, HYUSD>().await?;
+    let hylo = build_test_router_client()?;
+    let args = hylo
+      .build_transaction_data::<CBBTC, HYUSD>(RouterArgs {
+        amount: amount_cbbtc.bits,
+        user: TESTER,
+        slippage_config: None,
+      })
+      .await?;
+    let tx = hylo.build_simulation_transaction(&TESTER, &args).await?;
+    let sim = hylo
+      .simulate_transaction_return::<MintStablecoinExoEvent>(&tx)
+      .await?;
+    let quote = jup.quote(&quote_params)?;
+    let collateral_deposited: UFix64<N9> =
+      sim.collateral_deposited.try_into()?;
+    let fees: UFix64<N9> = sim.fees_deposited.try_into()?;
+    let fee_base = collateral_deposited
+      .checked_add(&fees)
+      .ok_or(anyhow!("fee_base"))?;
+    let in_amt: UFix64<N8> = fee_base.checked_convert().context("N9->N8")?;
+    assert_eq!(in_amt.bits, quote.in_amount);
+    assert_eq!(sim.minted.bits, quote.out_amount);
+    assert_eq!(sim.fees_deposited.bits, quote.fee_amount);
+    let fee_pct = fee_pct_decimal(fees, fee_base)?;
+    assert_eq!(fee_pct, quote.fee_pct);
+    Ok(())
+  }
+
+  #[tokio::test]
+  async fn hyusd_to_cbbtc_redeem_check() -> Result<()> {
+    let amount_hyusd = UFix64::<N6>::one();
+    let quote_params = QuoteParams {
+      amount: amount_hyusd.bits,
+      input_mint: HYUSD::MINT,
+      output_mint: CBBTC::MINT,
+      swap_mode: SwapMode::ExactIn,
+    };
+    let jup = build_jupiter_pair::<CBBTC, HYUSD>().await?;
+    let hylo = build_test_router_client()?;
+    let args = hylo
+      .build_transaction_data::<HYUSD, CBBTC>(RouterArgs {
+        amount: amount_hyusd.bits,
+        user: TESTER,
+        slippage_config: None,
+      })
+      .await?;
+    let tx = hylo.build_simulation_transaction(&TESTER, &args).await?;
+    let sim = hylo
+      .simulate_transaction_return::<RedeemStablecoinExoEvent>(&tx)
+      .await?;
+    let quote = jup.quote(&quote_params)?;
+    assert_eq!(sim.redeemed.bits, quote.in_amount);
+    let collateral_withdrawn: UFix64<N9> =
+      sim.collateral_withdrawn.try_into()?;
+    let out: UFix64<N8> =
+      collateral_withdrawn.checked_convert().context("N9->N8")?;
+    assert_eq!(out.bits, quote.out_amount);
+    assert_eq!(sim.fees_deposited.bits, quote.fee_amount);
+    let fees: UFix64<N9> = sim.fees_deposited.try_into()?;
+    let fee_base = collateral_withdrawn
+      .checked_add(&fees)
+      .ok_or(anyhow!("fee_base"))?;
+    let fee_pct = fee_pct_decimal(fees, fee_base)?;
+    assert_eq!(fee_pct, quote.fee_pct);
+    Ok(())
+  }
+
+  #[tokio::test]
+  async fn cbbtc_to_xbtc_mint_check() -> Result<()> {
+    let amount_cbbtc = UFix64::<N8>::one();
+    let quote_params = QuoteParams {
+      amount: amount_cbbtc.bits,
+      input_mint: CBBTC::MINT,
+      output_mint: XBTC::MINT,
+      swap_mode: SwapMode::ExactIn,
+    };
+    let jup = build_jupiter_pair::<CBBTC, XBTC>().await?;
+    let hylo = build_test_router_client()?;
+    let args = hylo
+      .build_transaction_data::<CBBTC, XBTC>(RouterArgs {
+        amount: amount_cbbtc.bits,
+        user: TESTER,
+        slippage_config: None,
+      })
+      .await?;
+    let tx = hylo.build_simulation_transaction(&TESTER, &args).await?;
+    let sim = hylo
+      .simulate_transaction_return::<MintLevercoinExoEvent>(&tx)
+      .await?;
+    let quote = jup.quote(&quote_params)?;
+    let collateral_deposited: UFix64<N9> =
+      sim.collateral_deposited.try_into()?;
+    let fees: UFix64<N9> = sim.fees_deposited.try_into()?;
+    let fee_base = collateral_deposited
+      .checked_add(&fees)
+      .ok_or(anyhow!("fee_base"))?;
+    let in_amt: UFix64<N8> = fee_base.checked_convert().context("N9->N8")?;
+    assert_eq!(in_amt.bits, quote.in_amount);
+    assert_eq!(sim.minted.bits, quote.out_amount);
+    assert_eq!(sim.fees_deposited.bits, quote.fee_amount);
+    let fee_pct = fee_pct_decimal(fees, fee_base)?;
+    assert_eq!(fee_pct, quote.fee_pct);
+    Ok(())
+  }
+
+  #[tokio::test]
+  async fn xbtc_to_cbbtc_redeem_check() -> Result<()> {
+    let amount_xbtc = UFix64::<N6>::one();
+    let quote_params = QuoteParams {
+      amount: amount_xbtc.bits,
+      input_mint: XBTC::MINT,
+      output_mint: CBBTC::MINT,
+      swap_mode: SwapMode::ExactIn,
+    };
+    let jup = build_jupiter_pair::<CBBTC, XBTC>().await?;
+    let hylo = build_test_router_client()?;
+    let args = hylo
+      .build_transaction_data::<XBTC, CBBTC>(RouterArgs {
+        amount: amount_xbtc.bits,
+        user: TESTER,
+        slippage_config: None,
+      })
+      .await?;
+    let tx = hylo.build_simulation_transaction(&TESTER, &args).await?;
+    let sim = hylo
+      .simulate_transaction_return::<RedeemLevercoinExoEvent>(&tx)
+      .await?;
+    let quote = jup.quote(&quote_params)?;
+    assert_eq!(sim.redeemed.bits, quote.in_amount);
+    let collateral_withdrawn: UFix64<N9> =
+      sim.collateral_withdrawn.try_into()?;
+    let out: UFix64<N8> =
+      collateral_withdrawn.checked_convert().context("N9->N8")?;
+    assert_eq!(out.bits, quote.out_amount);
+    assert_eq!(sim.fees_deposited.bits, quote.fee_amount);
+    let fees: UFix64<N9> = sim.fees_deposited.try_into()?;
+    let fee_base = collateral_withdrawn
+      .checked_add(&fees)
+      .ok_or(anyhow!("fee_base"))?;
+    let fee_pct = fee_pct_decimal(fees, fee_base)?;
+    assert_eq!(fee_pct, quote.fee_pct);
+    Ok(())
+  }
+
+  #[tokio::test]
+  async fn hyusd_to_xbtc_convert_check() -> Result<()> {
+    let amount_hyusd = UFix64::<N6>::one();
+    let quote_params = QuoteParams {
+      amount: amount_hyusd.bits,
+      input_mint: HYUSD::MINT,
+      output_mint: XBTC::MINT,
+      swap_mode: SwapMode::ExactIn,
+    };
+    let jup = build_jupiter_pair::<HYUSD, XBTC>().await?;
+    let hylo = build_test_router_client()?;
+    let args = hylo
+      .build_transaction_data::<HYUSD, XBTC>(RouterArgs {
+        amount: amount_hyusd.bits,
+        user: TESTER,
+        slippage_config: None,
+      })
+      .await?;
+    let tx = hylo.build_simulation_transaction(&TESTER, &args).await?;
+    let sim = hylo
+      .simulate_transaction_return::<ConvertStableToLeverExoEvent>(&tx)
+      .await?;
+    let quote = jup.quote(&quote_params)?;
+    let fees: UFix64<N6> = sim.stablecoin_fees.try_into()?;
+    let burned: UFix64<N6> = sim.stablecoin_burned.try_into()?;
+    let total_in = fees.checked_add(&burned).ok_or(anyhow!("total_in"))?;
+    assert_eq!(total_in.bits, quote.in_amount);
+    assert_eq!(sim.levercoin_minted.bits, quote.out_amount);
+    assert_eq!(sim.stablecoin_fees.bits, quote.fee_amount);
+    let fee_pct = fee_pct_decimal(fees, total_in)?;
+    assert_eq!(fee_pct, quote.fee_pct);
+    Ok(())
+  }
+
+  #[tokio::test]
+  async fn xbtc_to_hyusd_convert_check() -> Result<()> {
+    let amount_xbtc = UFix64::<N6>::one();
+    let quote_params = QuoteParams {
+      amount: amount_xbtc.bits,
+      input_mint: XBTC::MINT,
+      output_mint: HYUSD::MINT,
+      swap_mode: SwapMode::ExactIn,
+    };
+    let jup = build_jupiter_pair::<HYUSD, XBTC>().await?;
+    let hylo = build_test_router_client()?;
+    let args = hylo
+      .build_transaction_data::<XBTC, HYUSD>(RouterArgs {
+        amount: amount_xbtc.bits,
+        user: TESTER,
+        slippage_config: None,
+      })
+      .await?;
+    let tx = hylo.build_simulation_transaction(&TESTER, &args).await?;
+    let sim = hylo
+      .simulate_transaction_return::<ConvertLeverToStableExoEvent>(&tx)
+      .await?;
+    let quote = jup.quote(&quote_params)?;
+    assert_eq!(sim.levercoin_burned.bits, quote.in_amount);
+    assert_eq!(sim.stablecoin_minted_user.bits, quote.out_amount);
+    assert_eq!(sim.stablecoin_minted_fees.bits, quote.fee_amount);
+    let fees: UFix64<N6> = sim.stablecoin_minted_fees.try_into()?;
+    let out: UFix64<N6> = sim.stablecoin_minted_user.try_into()?;
+    let total_in = fees.checked_add(&out).ok_or(anyhow!("total_in"))?;
+    let fee_pct = fee_pct_decimal(fees, total_in)?;
+    assert_eq!(fee_pct, quote.fee_pct);
     Ok(())
   }
 


### PR DESCRIPTION
Previously the rebalance price curve construction failed if the
oracle-derived floor/ceil exceeded the configured deviation tolerance.
Instead, clamp the projected prices into the tolerance band so the curve
defaults to the configured discount rather than rejecting.

Add some odds and ends from earn pool improvements as well.
