### PR TITLE
Update Pyth receiver feeds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2555,11 +2555,12 @@ dependencies = [
 
 [[package]]
 name = "pyth-solana-receiver-sdk"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99df99fe99bd2f286bf3ee6364e611ef4d91a7b330c863dfc32f06c44e863c2f"
+checksum = "209892afe495433c5eae9406a76eedc1409100614727495348abdc91916154dd"
 dependencies = [
  "anchor-lang",
+ "cfg-if",
  "hex",
  "pythnet-sdk",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ hylo-jupiter-amm-interface = "0.6.0"
 more-asserts = "0.3.1"
 mpl-token-metadata = "5.1.1"
 proptest = "1.5.0"
-pyth-solana-receiver-sdk = "=1.1.0"
+pyth-solana-receiver-sdk = { version = "=1.2.0", features = ["pro-compatible"] }
 rust_decimal = "1.37.2"
 serde = "1.0.225"
 serde_json = "1.0.140"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.0.0"
+version = "2.0.0"
 edition = "2021"
 license = "MPL-2.0"
 homepage = "https://hylo.so"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.0.0"
+version = "1.0.0"
 edition = "2021"
 license = "MPL-2.0"
 homepage = "https://hylo.so"

--- a/hylo-core/src/pyth.rs
+++ b/hylo-core/src/pyth.rs
@@ -28,7 +28,7 @@ pub const SOL_USD: PythFeed = PythFeed {
     239, 13, 139, 111, 218, 44, 235, 164, 29, 161, 93, 64, 149, 209, 218, 57,
     42, 13, 47, 142, 208, 198, 199, 188, 15, 76, 250, 200, 194, 128, 181, 109,
   ],
-  address: pubkey!("7UVimffxr9ow1uXYxsr4LHAcV58mLzhmwaeKvJ1pjLiE"),
+  address: pubkey!("7AviUf9nL62mcxNbQGKm4nKDQnPjswo6c5MX4D57HmyE"),
 };
 
 pub const BTC_USD: PythFeed = PythFeed {
@@ -36,7 +36,7 @@ pub const BTC_USD: PythFeed = PythFeed {
     230, 45, 246, 200, 180, 168, 95, 225, 166, 125, 180, 77, 193, 45, 229, 219,
     51, 15, 122, 198, 107, 114, 220, 101, 138, 254, 223, 15, 74, 65, 91, 67,
   ],
-  address: pubkey!("4cSM2e6rvbGQUFiJbqytoVMi5GgghSMr8LwVrT9VPSPo"),
+  address: pubkey!("APgzQGGdv2qCgBkX6aHVkrGePtBVDDg68GiqaM7rmtf5"),
 };
 
 pub const USDC_USD: PythFeed = PythFeed {
@@ -44,7 +44,7 @@ pub const USDC_USD: PythFeed = PythFeed {
     234, 160, 32, 198, 28, 196, 121, 113, 40, 19, 70, 28, 225, 83, 137, 74,
     150, 166, 192, 11, 33, 237, 12, 252, 39, 152, 209, 249, 169, 233, 201, 74,
   ],
-  address: pubkey!("Dpw1EAVrSB1ibxiDQyTAW6Zip3J4Btk2x4SgApQCeFbX"),
+  address: pubkey!("6HAuqASbHEh4w4REJEUUUCginTLfj1kwCh215ZLtMkrT"),
 };
 
 #[derive(Copy, Clone)]

--- a/hylo-core/src/pyth.rs
+++ b/hylo-core/src/pyth.rs
@@ -1,6 +1,7 @@
 use anchor_lang::prelude::*;
 use fix::prelude::*;
 use fix::typenum::{Integer, Z0};
+use hylo_idl::pda::{BTC_USD_PYTH_FEED, SOL_USD_PYTH_FEED, USDC_USD_PYTH_FEED};
 use pyth_solana_receiver_sdk::price_update::{
   FeedId, PriceUpdateV2, VerificationLevel,
 };
@@ -28,7 +29,7 @@ pub const SOL_USD: PythFeed = PythFeed {
     239, 13, 139, 111, 218, 44, 235, 164, 29, 161, 93, 64, 149, 209, 218, 57,
     42, 13, 47, 142, 208, 198, 199, 188, 15, 76, 250, 200, 194, 128, 181, 109,
   ],
-  address: pubkey!("7AviUf9nL62mcxNbQGKm4nKDQnPjswo6c5MX4D57HmyE"),
+  address: SOL_USD_PYTH_FEED,
 };
 
 pub const BTC_USD: PythFeed = PythFeed {
@@ -36,7 +37,7 @@ pub const BTC_USD: PythFeed = PythFeed {
     230, 45, 246, 200, 180, 168, 95, 225, 166, 125, 180, 77, 193, 45, 229, 219,
     51, 15, 122, 198, 107, 114, 220, 101, 138, 254, 223, 15, 74, 65, 91, 67,
   ],
-  address: pubkey!("APgzQGGdv2qCgBkX6aHVkrGePtBVDDg68GiqaM7rmtf5"),
+  address: BTC_USD_PYTH_FEED,
 };
 
 pub const USDC_USD: PythFeed = PythFeed {
@@ -44,7 +45,7 @@ pub const USDC_USD: PythFeed = PythFeed {
     234, 160, 32, 198, 28, 196, 121, 113, 40, 19, 70, 28, 225, 83, 137, 74,
     150, 166, 192, 11, 33, 237, 12, 252, 39, 152, 209, 249, 169, 233, 201, 74,
   ],
-  address: pubkey!("6HAuqASbHEh4w4REJEUUUCginTLfj1kwCh215ZLtMkrT"),
+  address: USDC_USD_PYTH_FEED,
 };
 
 #[derive(Copy, Clone)]

--- a/hylo-idl/src/pda.rs
+++ b/hylo-idl/src/pda.rs
@@ -221,13 +221,13 @@ pub const EARN_POOL_PROGRAM_DATA: Pubkey = progdata(earn_pool::ID);
 pub const EXCHANGE_PROGRAM_DATA: Pubkey = progdata(exchange::ID);
 
 pub const SOL_USD_PYTH_FEED: Pubkey =
-  pubkey!("7UVimffxr9ow1uXYxsr4LHAcV58mLzhmwaeKvJ1pjLiE");
+  pubkey!("7AviUf9nL62mcxNbQGKm4nKDQnPjswo6c5MX4D57HmyE");
 
 pub const USDC_USD_PYTH_FEED: Pubkey =
-  pubkey!("Dpw1EAVrSB1ibxiDQyTAW6Zip3J4Btk2x4SgApQCeFbX");
+  pubkey!("6HAuqASbHEh4w4REJEUUUCginTLfj1kwCh215ZLtMkrT");
 
 pub const BTC_USD_PYTH_FEED: Pubkey =
-  pubkey!("4cSM2e6rvbGQUFiJbqytoVMi5GgghSMr8LwVrT9VPSPo");
+  pubkey!("APgzQGGdv2qCgBkX6aHVkrGePtBVDDg68GiqaM7rmtf5");
 
 pub const DEAD: Pubkey = pda!(exchange::ID, exchange::constants::DEAD);
 


### PR DESCRIPTION
Updates Pyth receiver SDK to 1.2.0 with pro-compatible and refreshes the SOL/USD, BTC/USD, and USDC/USD feed accounts for the Pyth Core upgrade.
