### PR TITLE
hylo-quotes: fix USDC swap fee precision

### DIFF
--- a/hylo-quotes/src/protocol_state/state.rs
+++ b/hylo-quotes/src/protocol_state/state.rs
@@ -13,7 +13,7 @@ use fix::prelude::*;
 use hylo_core::asset_swap_config::AssetSwapConfig;
 use hylo_core::conversion::UsdcStablecoinConversion;
 use hylo_core::exchange_context::{ExoExchangeContext, LstExchangeContext};
-use hylo_core::fees::controller::{FeeExtract, LevercoinFees};
+use hylo_core::fees::controller::LevercoinFees;
 use hylo_core::idl::earn_pool::accounts::PoolConfig;
 use hylo_core::idl::exchange::accounts::{ExoPair, Hylo, LstHeader, UsdcPair};
 use hylo_core::lst::stake_pool::SplStakePool;
@@ -33,7 +33,7 @@ pub struct UsdcExchangeState {
   /// USDC/USD oracle price range
   pub usdc_usd_price: hylo_core::pyth::PriceRange<N9>,
   /// Swap fee extracted on USDC operations
-  pub swap_fee: UFix64<N9>,
+  pub swap_fee: UFix64<N4>,
 }
 
 impl UsdcExchangeState {
@@ -43,17 +43,6 @@ impl UsdcExchangeState {
     UsdcStablecoinConversion {
       usdc_usd_price: self.usdc_usd_price,
     }
-  }
-
-  /// Applies the swap fee to an amount at any precision.
-  ///
-  /// # Errors
-  /// * Arithmetic failure in fee extraction
-  pub fn apply_fee<Exp>(&self, amount: UFix64<Exp>) -> Result<FeeExtract<Exp>>
-  where
-    UFix64<N9>: FixExt,
-  {
-    Ok(FeeExtract::new(self.swap_fee, amount)?)
   }
 }
 

--- a/hylo-quotes/src/token_operation/exchange.rs
+++ b/hylo-quotes/src/token_operation/exchange.rs
@@ -284,7 +284,7 @@ impl<C: SolanaClock> TokenOperation<USDC, HYUSD> for ProtocolState<C> {
     let FeeExtract {
       fees_extracted,
       amount_remaining,
-    } = usdc_state.apply_fee(amount_n9)?;
+    } = FeeExtract::new(usdc_state.swap_fee, amount_n9)?;
     let out_amount = usdc_state
       .conversion()
       .deposit_to_stablecoin(amount_remaining)?;
@@ -313,7 +313,7 @@ impl<C: SolanaClock> TokenOperation<HYUSD, USDC> for ProtocolState<C> {
     let FeeExtract {
       fees_extracted,
       amount_remaining,
-    } = usdc_state.apply_fee(in_amount)?;
+    } = FeeExtract::new(usdc_state.swap_fee, in_amount)?;
     let usdc_out_n9 = usdc_state
       .conversion()
       .stablecoin_to_withdrawal(amount_remaining)?;


### PR DESCRIPTION
take 3 of the same-old; this one just builds over pyth-core-upgrade