### PR TITLE
refactor(trigger-orders): align SDK with renamed program surface

### DIFF
--- a/hylo-clients/src/lib.rs
+++ b/hylo-clients/src/lib.rs
@@ -31,6 +31,8 @@
 //!   program
 //! - [`earn_pool_client::EarnPoolClient`] — Admin operations for the earn pool
 //!   program
+//! - [`trigger_orders_client::TriggerOrdersClient`] — Permissionless
+//!   trigger-order placement, cancellation, and execution
 
 pub mod earn_pool_client;
 pub mod exchange_client;

--- a/hylo-clients/src/prelude.rs
+++ b/hylo-clients/src/prelude.rs
@@ -17,7 +17,7 @@ pub use crate::router_client::{
 pub use crate::transaction::{BuildTransactionData, TransactionSyntax};
 pub use crate::trigger_orders_client::{
   ConvertDirection, ExecutabilityBlocker, PairTarget, TriggerDirection,
-  TriggerOrder, TriggerOrderCancelled, TriggerOrderCreated, TriggerOrderFilled,
-  TriggerOrdersClient, TriggerOutcome, CONSERVATIVE_EXECUTE_CU,
-  EXECUTOR_TIP_LAMPORTS,
+  TriggerOrder, TriggerOrderCancelledEvent, TriggerOrderCreatedEvent,
+  TriggerOrderFilledEvent, TriggerOrdersClient, TriggerOutcome,
+  CONSERVATIVE_EXECUTE_CU, EXECUTOR_TIP_LAMPORTS,
 };

--- a/hylo-clients/src/trigger_orders_client.rs
+++ b/hylo-clients/src/trigger_orders_client.rs
@@ -17,7 +17,7 @@ pub use hylo_idl::trigger_orders::accounts::TriggerOrder;
 use hylo_idl::trigger_orders::client::args;
 pub use hylo_idl::trigger_orders::constants::EXECUTOR_TIP_LAMPORTS;
 pub use hylo_idl::trigger_orders::events::{
-  TriggerOrderCancelled, TriggerOrderCreated, TriggerOrderFilled,
+  TriggerOrderCancelledEvent, TriggerOrderCreatedEvent, TriggerOrderFilledEvent,
 };
 use hylo_idl::trigger_orders::instruction_builders;
 pub use hylo_idl::trigger_orders::types::{
@@ -71,7 +71,7 @@ impl TriggerOrdersClient {
   // which do await) and so future escrow/balance lookups can be added without
   // a breaking API change.
   #[allow(clippy::unused_async)]
-  pub async fn create_order_s2l_lst(
+  pub async fn create_order_stable_to_lever_lst(
     &self,
     nonce: u64,
     escrow_amount: u64,
@@ -82,10 +82,10 @@ impl TriggerOrdersClient {
     let owner = self.keypair.pubkey();
     let (order, _) =
       pda::trigger_order_lst(owner, ConvertDirection::StableToLever, nonce);
-    let ix = instruction_builders::create_order_s2l_lst(
+    let ix = instruction_builders::create_order_stable_to_lever_lst(
       owner,
       order,
-      &args::CreateOrderS2lLst {
+      &args::CreateOrderStableToLeverLst {
         nonce,
         escrow_amount,
         trigger_price,
@@ -96,12 +96,12 @@ impl TriggerOrdersClient {
     Ok(VersionedTransactionData::one(ix))
   }
 
-  /// As `create_order_s2l_lst`, but for an EXO pair.
+  /// As `create_order_stable_to_lever_lst`, but for an EXO pair.
   ///
   /// # Errors
   /// * Failed to build transaction instructions
-  #[allow(clippy::unused_async)] // async for surface uniformity; see s2l_lst.
-  pub async fn create_order_s2l_exo(
+  #[allow(clippy::unused_async)] // async for surface uniformity; see stable_to_lever_lst.
+  pub async fn create_order_stable_to_lever_exo(
     &self,
     collateral_mint: Pubkey,
     nonce: u64,
@@ -117,11 +117,11 @@ impl TriggerOrdersClient {
       collateral_mint,
       nonce,
     );
-    let ix = instruction_builders::create_order_s2l_exo(
+    let ix = instruction_builders::create_order_stable_to_lever_exo(
       owner,
       order,
       collateral_mint,
-      &args::CreateOrderS2lExo {
+      &args::CreateOrderStableToLeverExo {
         nonce,
         escrow_amount,
         trigger_price,
@@ -136,8 +136,8 @@ impl TriggerOrdersClient {
   ///
   /// # Errors
   /// * Failed to build transaction instructions
-  #[allow(clippy::unused_async)] // async for surface uniformity; see s2l_lst.
-  pub async fn create_order_l2s_lst(
+  #[allow(clippy::unused_async)] // async for surface uniformity; see stable_to_lever_lst.
+  pub async fn create_order_lever_to_stable_lst(
     &self,
     nonce: u64,
     escrow_amount: u64,
@@ -148,10 +148,10 @@ impl TriggerOrdersClient {
     let owner = self.keypair.pubkey();
     let (order, _) =
       pda::trigger_order_lst(owner, ConvertDirection::LeverToStable, nonce);
-    let ix = instruction_builders::create_order_l2s_lst(
+    let ix = instruction_builders::create_order_lever_to_stable_lst(
       owner,
       order,
-      &args::CreateOrderL2sLst {
+      &args::CreateOrderLeverToStableLst {
         nonce,
         escrow_amount,
         trigger_price,
@@ -166,8 +166,8 @@ impl TriggerOrdersClient {
   ///
   /// # Errors
   /// * Failed to build transaction instructions
-  #[allow(clippy::unused_async)] // async for surface uniformity; see s2l_lst.
-  pub async fn create_order_l2s_exo(
+  #[allow(clippy::unused_async)] // async for surface uniformity; see stable_to_lever_lst.
+  pub async fn create_order_lever_to_stable_exo(
     &self,
     collateral_mint: Pubkey,
     nonce: u64,
@@ -183,11 +183,11 @@ impl TriggerOrdersClient {
       collateral_mint,
       nonce,
     );
-    let ix = instruction_builders::create_order_l2s_exo(
+    let ix = instruction_builders::create_order_lever_to_stable_exo(
       owner,
       order,
       collateral_mint,
-      &args::CreateOrderL2sExo {
+      &args::CreateOrderLeverToStableExo {
         nonce,
         escrow_amount,
         trigger_price,
@@ -198,14 +198,15 @@ impl TriggerOrdersClient {
     Ok(VersionedTransactionData::one(ix))
   }
 
-  /// Cancel an s2l trigger order. Refunds HYUSD escrow + executor tip to
-  /// the owner via Anchor's `close = owner`. Handles both LST and EXO s2l
-  /// (the s2l escrow is always HYUSD), selected by `pair_target`.
+  /// Cancel a stable-to-lever trigger order. Refunds HYUSD escrow + executor
+  /// tip to the owner via Anchor's `close = owner`. Handles both LST and EXO
+  /// stable-to-lever (the stable-to-lever escrow is always HYUSD), selected by
+  /// `pair_target`.
   ///
   /// # Errors
   /// * Failed to build transaction instructions
-  #[allow(clippy::unused_async)] // async for surface uniformity; see s2l_lst.
-  pub async fn cancel_order_s2l(
+  #[allow(clippy::unused_async)] // async for surface uniformity; see stable_to_lever_lst.
+  pub async fn cancel_order_stable_to_lever(
     &self,
     nonce: u64,
     pair_target: PairTarget,
@@ -222,41 +223,42 @@ impl TriggerOrdersClient {
         nonce,
       ),
     };
-    let ix = instruction_builders::cancel_order_s2l(
+    let ix = instruction_builders::cancel_order_stable_to_lever(
       owner,
       order,
-      &args::CancelOrderS2l {},
+      &args::CancelOrderStableToLever {},
     );
     Ok(VersionedTransactionData::one(ix))
   }
 
-  /// Cancel an l2s LST order. Refunds xSOL escrow + tip via `close = owner`.
+  /// Cancel a lever-to-stable LST order. Refunds xSOL escrow + tip via
+  /// `close = owner`.
   ///
   /// # Errors
   /// * Failed to build transaction instructions
-  #[allow(clippy::unused_async)] // async for surface uniformity; see s2l_lst.
-  pub async fn cancel_order_l2s_lst(
+  #[allow(clippy::unused_async)] // async for surface uniformity; see stable_to_lever_lst.
+  pub async fn cancel_order_lever_to_stable_lst(
     &self,
     nonce: u64,
   ) -> Result<VersionedTransactionData> {
     let owner = self.keypair.pubkey();
     let (order, _) =
       pda::trigger_order_lst(owner, ConvertDirection::LeverToStable, nonce);
-    let ix = instruction_builders::cancel_order_l2s_lst(
+    let ix = instruction_builders::cancel_order_lever_to_stable_lst(
       owner,
       order,
-      &args::CancelOrderL2sLst {},
+      &args::CancelOrderLeverToStableLst {},
     );
     Ok(VersionedTransactionData::one(ix))
   }
 
-  /// Cancel an l2s EXO order. Refunds the per-collateral levercoin escrow +
-  /// tip.
+  /// Cancel a lever-to-stable EXO order. Refunds the per-collateral levercoin
+  /// escrow + tip.
   ///
   /// # Errors
   /// * Failed to build transaction instructions
-  #[allow(clippy::unused_async)] // async for surface uniformity; see s2l_lst.
-  pub async fn cancel_order_l2s_exo(
+  #[allow(clippy::unused_async)] // async for surface uniformity; see stable_to_lever_lst.
+  pub async fn cancel_order_lever_to_stable_exo(
     &self,
     collateral_mint: Pubkey,
     nonce: u64,
@@ -268,11 +270,11 @@ impl TriggerOrdersClient {
       collateral_mint,
       nonce,
     );
-    let ix = instruction_builders::cancel_order_l2s_exo(
+    let ix = instruction_builders::cancel_order_lever_to_stable_exo(
       owner,
       order,
       collateral_mint,
-      &args::CancelOrderL2sExo {},
+      &args::CancelOrderLeverToStableExo {},
     );
     Ok(VersionedTransactionData::one(ix))
   }
@@ -283,7 +285,7 @@ impl TriggerOrdersClient {
   /// # Errors
   /// * RPC error fetching `Hylo`
   /// * Account deserialization failure
-  pub async fn execute_order_s2l_lst(
+  pub async fn execute_order_stable_to_lever_lst(
     &self,
     owner: Pubkey,
     nonce: u64,
@@ -292,7 +294,7 @@ impl TriggerOrdersClient {
     let (order, _) =
       pda::trigger_order_lst(owner, ConvertDirection::StableToLever, nonce);
     let hylo: Hylo = self.program.account(pda::HYLO).await?;
-    let ix = instruction_builders::execute_order_s2l_lst(
+    let ix = instruction_builders::execute_order_stable_to_lever_lst(
       executor, owner, order, &hylo,
     );
     Ok(
@@ -301,12 +303,12 @@ impl TriggerOrdersClient {
     )
   }
 
-  /// As `execute_order_s2l_lst`, but lever→stable.
+  /// As `execute_order_stable_to_lever_lst`, but lever→stable.
   ///
   /// # Errors
   /// * RPC error fetching `Hylo`
   /// * Account deserialization failure
-  pub async fn execute_order_l2s_lst(
+  pub async fn execute_order_lever_to_stable_lst(
     &self,
     owner: Pubkey,
     nonce: u64,
@@ -315,7 +317,7 @@ impl TriggerOrdersClient {
     let (order, _) =
       pda::trigger_order_lst(owner, ConvertDirection::LeverToStable, nonce);
     let hylo: Hylo = self.program.account(pda::HYLO).await?;
-    let ix = instruction_builders::execute_order_l2s_lst(
+    let ix = instruction_builders::execute_order_lever_to_stable_lst(
       executor, owner, order, &hylo,
     );
     Ok(
@@ -330,7 +332,7 @@ impl TriggerOrdersClient {
   /// # Errors
   /// * RPC error fetching `Hylo`/`ExoPair`
   /// * Account deserialization failure
-  pub async fn execute_order_s2l_exo(
+  pub async fn execute_order_stable_to_lever_exo(
     &self,
     owner: Pubkey,
     collateral_mint: Pubkey,
@@ -348,7 +350,7 @@ impl TriggerOrdersClient {
     let hylo: Hylo = self.program.account(pda::HYLO).await?;
     let exo_pair: ExoPair =
       self.program.account(pda::exo_pair(collateral_mint)).await?;
-    let ix = instruction_builders::execute_order_s2l_exo(
+    let ix = instruction_builders::execute_order_stable_to_lever_exo(
       executor,
       owner,
       order,
@@ -362,12 +364,13 @@ impl TriggerOrdersClient {
     )
   }
 
-  /// Lever→stable EXO. See `execute_order_s2l_exo` re: the `Hylo` fetch.
+  /// Lever→stable EXO. See `execute_order_stable_to_lever_exo` re: the `Hylo`
+  /// fetch.
   ///
   /// # Errors
   /// * RPC error fetching `Hylo`/`ExoPair`
   /// * Account deserialization failure
-  pub async fn execute_order_l2s_exo(
+  pub async fn execute_order_lever_to_stable_exo(
     &self,
     owner: Pubkey,
     collateral_mint: Pubkey,
@@ -383,7 +386,7 @@ impl TriggerOrdersClient {
     let hylo: Hylo = self.program.account(pda::HYLO).await?;
     let exo_pair: ExoPair =
       self.program.account(pda::exo_pair(collateral_mint)).await?;
-    let ix = instruction_builders::execute_order_l2s_exo(
+    let ix = instruction_builders::execute_order_lever_to_stable_exo(
       executor,
       owner,
       order,
@@ -398,98 +401,98 @@ impl TriggerOrdersClient {
   }
 
   // The `simulate_execute_order_*` methods below run TWO simulations (two RPC
-  // round-trips) to extract the outer `TriggerOrderFilled` and the inner Hylo
-  // `Convert*Event` separately. This is acceptable for v1 because `simulate_*`
-  // is low-frequency (keeper pre-flight, not the hot path); it could be
-  // optimized to a single simulation later (parse both events from one result
-  // via `parse_event_filtered`, which is designed to be called repeatedly on
-  // the same result).
+  // round-trips) to extract the outer `TriggerOrderFilledEvent` and the inner
+  // Hylo `Convert*Event` separately. This is acceptable for v1 because
+  // `simulate_*` is low-frequency (keeper pre-flight, not the hot path); it
+  // could be optimized to a single simulation later (parse both events from
+  // one result via `parse_event_filtered`, which is designed to be called
+  // repeatedly on the same result).
 
   /// Simulate the execute path; return both events the chain emits on
-  /// success: the trigger-orders `TriggerOrderFilled` AND the inner Hylo
+  /// success: the trigger-orders `TriggerOrderFilledEvent` AND the inner Hylo
   /// `ConvertStableToLeverLstEvent`.
   ///
   /// # Errors
   /// Simulation failure (CPI revert, account loading, CR-gate blockers);
   /// either event missing from the simulation result.
-  pub async fn simulate_execute_order_s2l_lst(
+  pub async fn simulate_execute_order_stable_to_lever_lst(
     &self,
     owner: Pubkey,
     nonce: u64,
-  ) -> Result<(TriggerOrderFilled, ConvertStableToLeverLstEvent)> {
-    let vtd = self.execute_order_s2l_lst(owner, nonce).await?;
+  ) -> Result<(TriggerOrderFilledEvent, ConvertStableToLeverLstEvent)> {
+    let vtd = self.execute_order_stable_to_lever_lst(owner, nonce).await?;
     let user = self.keypair.pubkey();
     let vt = self.build_simulation_transaction(&user, &vtd).await?;
-    let outer: TriggerOrderFilled =
+    let outer: TriggerOrderFilledEvent =
       self.simulate_transaction_event_filtered(&vt).await?;
     let inner: ConvertStableToLeverLstEvent =
       self.simulate_transaction_event_filtered(&vt).await?;
     Ok((outer, inner))
   }
 
-  /// Simulate the execute path; return the outer `TriggerOrderFilled` and the
-  /// inner Hylo `ConvertLeverToStableLstEvent`.
+  /// Simulate the execute path; return the outer `TriggerOrderFilledEvent` and
+  /// the inner Hylo `ConvertLeverToStableLstEvent`.
   ///
   /// # Errors
   /// Simulation failure (CPI revert, account loading, CR-gate blockers);
   /// either event missing from the simulation result.
-  pub async fn simulate_execute_order_l2s_lst(
+  pub async fn simulate_execute_order_lever_to_stable_lst(
     &self,
     owner: Pubkey,
     nonce: u64,
-  ) -> Result<(TriggerOrderFilled, ConvertLeverToStableLstEvent)> {
-    let vtd = self.execute_order_l2s_lst(owner, nonce).await?;
+  ) -> Result<(TriggerOrderFilledEvent, ConvertLeverToStableLstEvent)> {
+    let vtd = self.execute_order_lever_to_stable_lst(owner, nonce).await?;
     let user = self.keypair.pubkey();
     let vt = self.build_simulation_transaction(&user, &vtd).await?;
-    let outer: TriggerOrderFilled =
+    let outer: TriggerOrderFilledEvent =
       self.simulate_transaction_event_filtered(&vt).await?;
     let inner: ConvertLeverToStableLstEvent =
       self.simulate_transaction_event_filtered(&vt).await?;
     Ok((outer, inner))
   }
 
-  /// Simulate the EXO execute path; return the outer `TriggerOrderFilled` and
-  /// the inner Hylo `ConvertStableToLeverExoEvent`.
+  /// Simulate the EXO execute path; return the outer `TriggerOrderFilledEvent`
+  /// and the inner Hylo `ConvertStableToLeverExoEvent`.
   ///
   /// # Errors
   /// Simulation failure (CPI revert, account loading, CR-gate blockers);
   /// either event missing from the simulation result.
-  pub async fn simulate_execute_order_s2l_exo(
+  pub async fn simulate_execute_order_stable_to_lever_exo(
     &self,
     owner: Pubkey,
     collateral_mint: Pubkey,
     nonce: u64,
-  ) -> Result<(TriggerOrderFilled, ConvertStableToLeverExoEvent)> {
+  ) -> Result<(TriggerOrderFilledEvent, ConvertStableToLeverExoEvent)> {
     let vtd = self
-      .execute_order_s2l_exo(owner, collateral_mint, nonce)
+      .execute_order_stable_to_lever_exo(owner, collateral_mint, nonce)
       .await?;
     let user = self.keypair.pubkey();
     let vt = self.build_simulation_transaction(&user, &vtd).await?;
-    let outer: TriggerOrderFilled =
+    let outer: TriggerOrderFilledEvent =
       self.simulate_transaction_event_filtered(&vt).await?;
     let inner: ConvertStableToLeverExoEvent =
       self.simulate_transaction_event_filtered(&vt).await?;
     Ok((outer, inner))
   }
 
-  /// Simulate the EXO execute path; return the outer `TriggerOrderFilled` and
-  /// the inner Hylo `ConvertLeverToStableExoEvent`.
+  /// Simulate the EXO execute path; return the outer `TriggerOrderFilledEvent`
+  /// and the inner Hylo `ConvertLeverToStableExoEvent`.
   ///
   /// # Errors
   /// Simulation failure (CPI revert, account loading, CR-gate blockers);
   /// either event missing from the simulation result.
-  pub async fn simulate_execute_order_l2s_exo(
+  pub async fn simulate_execute_order_lever_to_stable_exo(
     &self,
     owner: Pubkey,
     collateral_mint: Pubkey,
     nonce: u64,
-  ) -> Result<(TriggerOrderFilled, ConvertLeverToStableExoEvent)> {
+  ) -> Result<(TriggerOrderFilledEvent, ConvertLeverToStableExoEvent)> {
     let vtd = self
-      .execute_order_l2s_exo(owner, collateral_mint, nonce)
+      .execute_order_lever_to_stable_exo(owner, collateral_mint, nonce)
       .await?;
     let user = self.keypair.pubkey();
     let vt = self.build_simulation_transaction(&user, &vtd).await?;
-    let outer: TriggerOrderFilled =
+    let outer: TriggerOrderFilledEvent =
       self.simulate_transaction_event_filtered(&vt).await?;
     let inner: ConvertLeverToStableExoEvent =
       self.simulate_transaction_event_filtered(&vt).await?;
@@ -572,7 +575,7 @@ mod tests {
   }
 
   #[tokio::test]
-  async fn create_order_s2l_lst_routes_to_correct_pda() {
+  async fn create_order_stable_to_lever_lst_routes_to_correct_pda() {
     let c = TriggerOrdersClient::new_random_keypair(
       Cluster::Localnet,
       CommitmentConfig::confirmed(),
@@ -581,7 +584,13 @@ mod tests {
     let owner = c.keypair().pubkey();
 
     let tx = c
-      .create_order_s2l_lst(7, 1000, 100, -8, TriggerDirection::AtOrAbove)
+      .create_order_stable_to_lever_lst(
+        7,
+        1000,
+        100,
+        -8,
+        TriggerDirection::AtOrAbove,
+      )
       .await
       .expect("build tx");
 
@@ -595,7 +604,7 @@ mod tests {
   }
 
   #[tokio::test]
-  async fn create_order_s2l_exo_derives_with_collateral_mint() {
+  async fn create_order_stable_to_lever_exo_derives_with_collateral_mint() {
     let c = TriggerOrdersClient::new_random_keypair(
       Cluster::Localnet,
       CommitmentConfig::confirmed(),
@@ -605,7 +614,7 @@ mod tests {
     let collateral_mint = Pubkey::new_unique();
 
     let tx = c
-      .create_order_s2l_exo(
+      .create_order_stable_to_lever_exo(
         collateral_mint,
         3,
         500,
@@ -629,7 +638,7 @@ mod tests {
   }
 
   #[tokio::test]
-  async fn create_order_l2s_lst_routes_to_correct_pda() {
+  async fn create_order_lever_to_stable_lst_routes_to_correct_pda() {
     let c = TriggerOrdersClient::new_random_keypair(
       Cluster::Localnet,
       CommitmentConfig::confirmed(),
@@ -638,7 +647,13 @@ mod tests {
     let owner = c.keypair().pubkey();
 
     let tx = c
-      .create_order_l2s_lst(11, 750, 25, -8, TriggerDirection::AtOrBelow)
+      .create_order_lever_to_stable_lst(
+        11,
+        750,
+        25,
+        -8,
+        TriggerDirection::AtOrBelow,
+      )
       .await
       .expect("build tx");
 
@@ -651,7 +666,7 @@ mod tests {
   }
 
   #[tokio::test]
-  async fn create_order_l2s_exo_derives_with_collateral_mint() {
+  async fn create_order_lever_to_stable_exo_derives_with_collateral_mint() {
     let c = TriggerOrdersClient::new_random_keypair(
       Cluster::Localnet,
       CommitmentConfig::confirmed(),
@@ -660,7 +675,7 @@ mod tests {
     let owner = c.keypair().pubkey();
     let collateral_mint = Pubkey::new_unique();
     let tx = c
-      .create_order_l2s_exo(
+      .create_order_lever_to_stable_exo(
         collateral_mint,
         9,
         2_000,
@@ -684,7 +699,7 @@ mod tests {
   }
 
   #[tokio::test]
-  async fn cancel_order_s2l_lst_derives_lst_pda() {
+  async fn cancel_order_stable_to_lever_lst_derives_lst_pda() {
     let c = TriggerOrdersClient::new_random_keypair(
       Cluster::Localnet,
       CommitmentConfig::confirmed(),
@@ -693,7 +708,7 @@ mod tests {
     let owner = c.keypair().pubkey();
 
     let tx = c
-      .cancel_order_s2l(11, PairTarget::Lst)
+      .cancel_order_stable_to_lever(11, PairTarget::Lst)
       .await
       .expect("build tx");
 
@@ -707,7 +722,7 @@ mod tests {
   }
 
   #[tokio::test]
-  async fn cancel_order_s2l_exo_derives_exo_pda() {
+  async fn cancel_order_stable_to_lever_exo_derives_exo_pda() {
     let c = TriggerOrdersClient::new_random_keypair(
       Cluster::Localnet,
       CommitmentConfig::confirmed(),
@@ -717,7 +732,7 @@ mod tests {
     let collateral_mint = Pubkey::new_unique();
 
     let tx = c
-      .cancel_order_s2l(12, PairTarget::Exo { collateral_mint })
+      .cancel_order_stable_to_lever(12, PairTarget::Exo { collateral_mint })
       .await
       .expect("build tx");
 
@@ -734,7 +749,7 @@ mod tests {
   }
 
   #[tokio::test]
-  async fn cancel_order_l2s_lst_derives_pda() {
+  async fn cancel_order_lever_to_stable_lst_derives_pda() {
     let c = TriggerOrdersClient::new_random_keypair(
       Cluster::Localnet,
       CommitmentConfig::confirmed(),
@@ -742,7 +757,10 @@ mod tests {
     .unwrap();
     let owner = c.keypair().pubkey();
 
-    let tx = c.cancel_order_l2s_lst(13).await.expect("build tx");
+    let tx = c
+      .cancel_order_lever_to_stable_lst(13)
+      .await
+      .expect("build tx");
 
     assert_eq!(tx.instructions.len(), 1);
     assert_eq!(tx.instructions[0].program_id, trigger_orders::ID);
@@ -753,7 +771,7 @@ mod tests {
   }
 
   #[tokio::test]
-  async fn cancel_order_l2s_exo_derives_pda() {
+  async fn cancel_order_lever_to_stable_exo_derives_pda() {
     let c = TriggerOrdersClient::new_random_keypair(
       Cluster::Localnet,
       CommitmentConfig::confirmed(),
@@ -763,7 +781,7 @@ mod tests {
     let collateral_mint = Pubkey::new_unique();
 
     let tx = c
-      .cancel_order_l2s_exo(collateral_mint, 14)
+      .cancel_order_lever_to_stable_exo(collateral_mint, 14)
       .await
       .expect("build tx");
 

--- a/hylo-clients/src/util.rs
+++ b/hylo-clients/src/util.rs
@@ -287,7 +287,7 @@ pub fn user_ata_instruction(user: &Pubkey, mint: &Pubkey) -> Instruction {
 mod parse_event_filtered_tests {
   use anchor_lang::{AnchorSerialize, Discriminator};
   use hylo_idl::exchange::events::ConvertStableToLeverLstEvent;
-  use hylo_idl::trigger_orders::events::TriggerOrderFilled;
+  use hylo_idl::trigger_orders::events::TriggerOrderFilledEvent;
   use hylo_idl::trigger_orders::types::{
     ConvertDirection, PairTarget, TriggerDirection,
   };
@@ -324,7 +324,7 @@ mod parse_event_filtered_tests {
 
   /// Builds a simulation response carrying the two given inner-instruction
   /// data blobs, mirroring a real `execute_order_*` tx that emits both a
-  /// `TriggerOrderFilled` and an inner Hylo convert event.
+  /// `TriggerOrderFilledEvent` and an inner Hylo convert event.
   fn response_with(
     blobs: Vec<String>,
   ) -> Response<RpcSimulateTransactionResult> {
@@ -349,8 +349,8 @@ mod parse_event_filtered_tests {
     }
   }
 
-  fn sample_trigger_order_filled() -> TriggerOrderFilled {
-    TriggerOrderFilled {
+  fn sample_trigger_order_filled() -> TriggerOrderFilledEvent {
+    TriggerOrderFilledEvent {
       order: Pubkey::new_unique(),
       owner: Pubkey::new_unique(),
       executor: Pubkey::new_unique(),
@@ -393,8 +393,8 @@ mod parse_event_filtered_tests {
     let resp =
       response_with(vec![encode_event(&filled), encode_event(&convert)]);
 
-    let got_filled: TriggerOrderFilled =
-      parse_event_filtered(&resp).expect("TriggerOrderFilled extractable");
+    let got_filled: TriggerOrderFilledEvent =
+      parse_event_filtered(&resp).expect("TriggerOrderFilledEvent extractable");
     let got_convert: ConvertStableToLeverLstEvent =
       parse_event_filtered(&resp).expect("convert event extractable");
 
@@ -418,7 +418,7 @@ mod parse_event_filtered_tests {
     let resp =
       response_with(vec![encode_event(&convert), encode_event(&filled)]);
 
-    let got_filled: TriggerOrderFilled =
+    let got_filled: TriggerOrderFilledEvent =
       parse_event_filtered(&resp).expect("fill event still extractable");
     assert_eq!(got_filled.nonce, 42);
   }
@@ -427,14 +427,15 @@ mod parse_event_filtered_tests {
   fn errors_when_event_absent() {
     let convert = sample_convert_event();
     let resp = response_with(vec![encode_event(&convert)]);
-    // No TriggerOrderFilled present → must error, not silently succeed.
-    let result: Result<TriggerOrderFilled> = parse_event_filtered(&resp);
+    // No TriggerOrderFilledEvent present → must error, not silently succeed.
+    let result: Result<TriggerOrderFilledEvent> = parse_event_filtered(&resp);
     assert!(result.is_err());
   }
 
   /// A discriminator-MATCHING but undeserializable blob: the correct event
   /// discriminator followed by a payload too short to borsh-decode (the first
-  /// field of `TriggerOrderFilled` is a 32-byte `Pubkey`, so 3 bytes fail).
+  /// field of `TriggerOrderFilledEvent` is a 32-byte `Pubkey`, so 3 bytes
+  /// fail).
   fn corrupt_blob<E: Discriminator>() -> String {
     let mut bytes = vec![0xAB_u8; 8];
     bytes.extend_from_slice(E::DISCRIMINATOR);
@@ -450,11 +451,11 @@ mod parse_event_filtered_tests {
   fn skips_discriminator_match_that_fails_to_deserialize() {
     let valid = sample_trigger_order_filled();
     let resp = response_with(vec![
-      corrupt_blob::<TriggerOrderFilled>(),
+      corrupt_blob::<TriggerOrderFilledEvent>(),
       encode_event(&valid),
     ]);
 
-    let got: TriggerOrderFilled = parse_event_filtered(&resp)
+    let got: TriggerOrderFilledEvent = parse_event_filtered(&resp)
       .expect("skips the corrupt match and returns the valid one");
     assert_eq!(got.nonce, 42);
   }

--- a/hylo-idl/idls/hylo_trigger_orders.json
+++ b/hylo-idl/idls/hylo_trigger_orders.json
@@ -5492,18 +5492,6 @@
           {
             "name": "bump",
             "type": "u8"
-          },
-          {
-            "name": "_reserved",
-            "docs": [
-              "Reserved for forward-compatible field additions without a migration."
-            ],
-            "type": {
-              "array": [
-                "u8",
-                64
-              ]
-            }
           }
         ]
       }

--- a/hylo-idl/idls/hylo_trigger_orders.json
+++ b/hylo-idl/idls/hylo_trigger_orders.json
@@ -8,16 +8,16 @@
   },
   "instructions": [
     {
-      "name": "cancel_order_l2s_exo",
+      "name": "cancel_order_lever_to_stable_exo",
       "discriminator": [
-        61,
-        165,
-        75,
-        198,
-        91,
-        170,
-        235,
-        153
+        47,
+        127,
+        17,
+        226,
+        125,
+        19,
+        22,
+        80
       ],
       "accounts": [
         {
@@ -239,21 +239,21 @@
       "args": [],
       "returns": {
         "defined": {
-          "name": "TriggerOrderCancelled"
+          "name": "TriggerOrderCancelledEvent"
         }
       }
     },
     {
-      "name": "cancel_order_l2s_lst",
+      "name": "cancel_order_lever_to_stable_lst",
       "discriminator": [
-        121,
-        201,
-        137,
-        113,
-        147,
-        216,
-        109,
-        177
+        68,
+        60,
+        120,
+        236,
+        126,
+        232,
+        1,
+        22
       ],
       "accounts": [
         {
@@ -455,21 +455,21 @@
       "args": [],
       "returns": {
         "defined": {
-          "name": "TriggerOrderCancelled"
+          "name": "TriggerOrderCancelledEvent"
         }
       }
     },
     {
-      "name": "cancel_order_s2l",
+      "name": "cancel_order_stable_to_lever",
       "discriminator": [
-        85,
-        20,
-        75,
-        12,
-        198,
-        159,
-        196,
-        50
+        45,
+        2,
+        38,
+        191,
+        74,
+        153,
+        31,
+        179
       ],
       "accounts": [
         {
@@ -672,21 +672,21 @@
       "args": [],
       "returns": {
         "defined": {
-          "name": "TriggerOrderCancelled"
+          "name": "TriggerOrderCancelledEvent"
         }
       }
     },
     {
-      "name": "create_order_l2s_exo",
+      "name": "create_order_lever_to_stable_exo",
       "discriminator": [
-        145,
-        7,
-        163,
-        2,
-        20,
-        124,
-        128,
-        146
+        18,
+        5,
+        47,
+        137,
+        57,
+        87,
+        9,
+        108
       ],
       "accounts": [
         {
@@ -923,8 +923,9 @@
             "above), so a malformed mint creates a PDA at an address unique to that",
             "owner/nonce/mint triple. No collision risk with other orders.",
             "2. Only the owner is harmed by an unfillable order — their levercoin goes",
-            "into a PDA they alone can drain via `cancel_order_l2s_exo`. There's no",
-            "path for an attacker to lock anyone else's funds via this vector.",
+            "into a PDA they alone can drain via",
+            "`cancel_order_lever_to_stable_exo`. There's no path for an attacker to",
+            "lock anyone else's funds via this vector.",
             "3. The cancel path doesn't read `ExoPair`, `Hylo`, or any pair-specific",
             "state. So even if Hylo deprecates this collateral, the owner can",
             "always recover. Funds-recoverability is structural, not policy.",
@@ -1011,21 +1012,21 @@
       ],
       "returns": {
         "defined": {
-          "name": "TriggerOrderCreated"
+          "name": "TriggerOrderCreatedEvent"
         }
       }
     },
     {
-      "name": "create_order_l2s_lst",
+      "name": "create_order_lever_to_stable_lst",
       "discriminator": [
-        217,
-        157,
-        106,
-        121,
-        230,
-        232,
-        238,
-        73
+        169,
+        244,
+        48,
+        59,
+        91,
+        86,
+        47,
+        4
       ],
       "accounts": [
         {
@@ -1295,21 +1296,21 @@
       ],
       "returns": {
         "defined": {
-          "name": "TriggerOrderCreated"
+          "name": "TriggerOrderCreatedEvent"
         }
       }
     },
     {
-      "name": "create_order_s2l_exo",
+      "name": "create_order_stable_to_lever_exo",
       "discriminator": [
+        64,
+        253,
+        226,
+        234,
         102,
-        197,
-        120,
-        21,
-        57,
-        139,
-        195,
-        202
+        182,
+        158,
+        44
       ],
       "accounts": [
         {
@@ -1534,8 +1535,9 @@
             "above), so a malformed mint creates a PDA at an address unique to that",
             "owner/nonce/mint triple. No collision risk with other orders.",
             "2. Only the owner is harmed by an unfillable order — their HYUSD goes",
-            "into a PDA they alone can drain via `cancel_order_s2l`. There's no",
-            "path for an attacker to lock anyone else's funds via this vector.",
+            "into a PDA they alone can drain via `cancel_order_stable_to_lever`.",
+            "There's no path for an attacker to lock anyone else's funds via this",
+            "vector.",
             "3. The cancel path doesn't read `ExoPair`, `Hylo`, or any pair-specific",
             "state. So even if Hylo deprecates this collateral, the owner can",
             "always recover. Funds-recoverability is structural, not policy.",
@@ -1622,21 +1624,21 @@
       ],
       "returns": {
         "defined": {
-          "name": "TriggerOrderCreated"
+          "name": "TriggerOrderCreatedEvent"
         }
       }
     },
     {
-      "name": "create_order_s2l_lst",
+      "name": "create_order_stable_to_lever_lst",
       "discriminator": [
-        1,
-        195,
-        39,
-        158,
-        147,
-        192,
-        10,
-        101
+        44,
+        239,
+        230,
+        43,
+        167,
+        109,
+        159,
+        75
       ],
       "accounts": [
         {
@@ -1907,21 +1909,21 @@
       ],
       "returns": {
         "defined": {
-          "name": "TriggerOrderCreated"
+          "name": "TriggerOrderCreatedEvent"
         }
       }
     },
     {
-      "name": "execute_order_l2s_exo",
+      "name": "execute_order_lever_to_stable_exo",
       "discriminator": [
-        112,
-        175,
-        205,
-        216,
-        129,
-        95,
-        184,
-        153
+        37,
+        208,
+        145,
+        18,
+        1,
+        120,
+        209,
+        189
       ],
       "accounts": [
         {
@@ -2606,21 +2608,21 @@
       "args": [],
       "returns": {
         "defined": {
-          "name": "TriggerOrderFilled"
+          "name": "TriggerOrderFilledEvent"
         }
       }
     },
     {
-      "name": "execute_order_l2s_lst",
+      "name": "execute_order_lever_to_stable_lst",
       "discriminator": [
-        96,
-        37,
-        224,
-        31,
-        190,
-        139,
-        223,
-        0
+        148,
+        194,
+        232,
+        208,
+        165,
+        164,
+        221,
+        71
       ],
       "accounts": [
         {
@@ -3079,21 +3081,21 @@
       "args": [],
       "returns": {
         "defined": {
-          "name": "TriggerOrderFilled"
+          "name": "TriggerOrderFilledEvent"
         }
       }
     },
     {
-      "name": "execute_order_s2l_exo",
+      "name": "execute_order_stable_to_lever_exo",
       "discriminator": [
-        29,
-        184,
-        147,
-        164,
-        106,
-        9,
-        121,
-        21
+        78,
+        24,
+        242,
+        4,
+        17,
+        60,
+        133,
+        89
       ],
       "accounts": [
         {
@@ -3778,21 +3780,21 @@
       "args": [],
       "returns": {
         "defined": {
-          "name": "TriggerOrderFilled"
+          "name": "TriggerOrderFilledEvent"
         }
       }
     },
     {
-      "name": "execute_order_s2l_lst",
+      "name": "execute_order_stable_to_lever_lst",
       "discriminator": [
-        26,
-        104,
-        100,
-        203,
-        82,
-        5,
-        112,
-        58
+        225,
+        97,
+        249,
+        74,
+        99,
+        214,
+        130,
+        114
       ],
       "accounts": [
         {
@@ -4251,7 +4253,7 @@
       "args": [],
       "returns": {
         "defined": {
-          "name": "TriggerOrderFilled"
+          "name": "TriggerOrderFilledEvent"
         }
       }
     }
@@ -4312,42 +4314,42 @@
   ],
   "events": [
     {
-      "name": "TriggerOrderCancelled",
+      "name": "TriggerOrderCancelledEvent",
       "discriminator": [
-        255,
-        151,
-        206,
-        140,
-        98,
-        153,
-        223,
-        121
-      ]
-    },
-    {
-      "name": "TriggerOrderCreated",
-      "discriminator": [
-        90,
-        78,
+        178,
+        127,
         39,
-        34,
-        130,
-        168,
-        79,
-        55
+        234,
+        87,
+        193,
+        7,
+        119
       ]
     },
     {
-      "name": "TriggerOrderFilled",
+      "name": "TriggerOrderCreatedEvent",
       "discriminator": [
-        124,
-        156,
-        201,
-        86,
-        158,
-        86,
-        183,
-        212
+        231,
+        191,
+        133,
+        0,
+        130,
+        0,
+        198,
+        83
+      ]
+    },
+    {
+      "name": "TriggerOrderFilledEvent",
+      "discriminator": [
+        72,
+        131,
+        117,
+        214,
+        75,
+        219,
+        32,
+        36
       ]
     }
   ],
@@ -4355,27 +4357,27 @@
     {
       "code": 6000,
       "name": "AmountTooSmall",
-      "msg": "escrow_amount must be > 0"
+      "msg": "Escrow amount must be greater than zero."
     },
     {
       "code": 6001,
       "name": "AccountMismatch",
-      "msg": "account does not match the order's pair target"
+      "msg": "Account does not match the order's pair target."
     },
     {
       "code": 6002,
       "name": "TriggerNotMet",
-      "msg": "price condition not met"
+      "msg": "Price condition not met."
     },
     {
       "code": 6003,
       "name": "Unauthorized",
-      "msg": "signer is not the order owner"
+      "msg": "Signer is not the order owner."
     },
     {
       "code": 6004,
       "name": "InvalidPythPrice",
-      "msg": "invalid pyth price update account, feed id, or expo"
+      "msg": "Invalid Pyth price update account, feed id, or exponent."
     }
   ],
   "types": [
@@ -5125,7 +5127,8 @@
           {
             "name": "convert_direction",
             "docs": [
-              "Direction of the Hylo convert ix this order will fire (s2l or l2s)."
+              "Direction of the Hylo convert ix this order will fire",
+              "(`stable_to_lever` or `lever_to_stable`)."
             ],
             "type": {
               "defined": {
@@ -5145,7 +5148,8 @@
             "name": "escrow_amount",
             "docs": [
               "Amount escrowed in the order's escrow vault. Unit depends on",
-              "`convert_direction`: HYUSD for s2l; xSOL or per-EXO levercoin for l2s."
+              "`convert_direction`: HYUSD for `stable_to_lever`; xSOL or per-EXO",
+              "levercoin for `lever_to_stable`."
             ],
             "type": "u64"
           },
@@ -5181,15 +5185,26 @@
           {
             "name": "bump",
             "type": "u8"
+          },
+          {
+            "name": "_reserved",
+            "docs": [
+              "Reserved for forward-compatible field additions without a migration."
+            ],
+            "type": {
+              "array": [
+                "u8",
+                64
+              ]
+            }
           }
         ]
       }
     },
     {
-      "name": "TriggerOrderCancelled",
+      "name": "TriggerOrderCancelledEvent",
       "docs": [
-        "Emitted at the end of `cancel_order_{s2l,l2s_lst,l2s_exo}` after the",
-        "refund completes."
+        "Emitted at the end of `cancel_order_*` after the refund completes."
       ],
       "type": {
         "kind": "struct",
@@ -5230,10 +5245,9 @@
       }
     },
     {
-      "name": "TriggerOrderCreated",
+      "name": "TriggerOrderCreatedEvent",
       "docs": [
-        "Emitted at the end of `create_order_{s2l,l2s}_{lst,exo}` after state",
-        "mutations succeed."
+        "Emitted at the end of `create_order_*` after state mutations succeed."
       ],
       "type": {
         "kind": "struct",
@@ -5269,7 +5283,8 @@
           {
             "name": "escrow_amount",
             "docs": [
-              "Amount escrowed (HYUSD for s2l, levercoin for l2s)."
+              "Amount escrowed (HYUSD for `stable_to_lever`, levercoin for",
+              "`lever_to_stable`)."
             ],
             "type": "u64"
           },
@@ -5297,11 +5312,11 @@
       }
     },
     {
-      "name": "TriggerOrderFilled",
+      "name": "TriggerOrderFilledEvent",
       "docs": [
-        "Emitted at the end of `execute_order_{s2l,l2s}_{lst,exo}` after the order",
-        "fills. `output_received` mirrors Hylo's convert event field",
-        "(`UFixValue64`) verbatim."
+        "Emitted at the end of `execute_order_*` after the order fills.",
+        "`output_received` mirrors Hylo's convert event field (`UFixValue64`)",
+        "verbatim."
       ],
       "type": {
         "kind": "struct",
@@ -5348,8 +5363,8 @@
           {
             "name": "output_received",
             "docs": [
-              "Amount minted to the owner's output ATA (levercoin for s2l, HYUSD for",
-              "l2s)."
+              "Amount minted to the owner's output ATA (levercoin for",
+              "`stable_to_lever`, HYUSD for `lever_to_stable`)."
             ],
             "type": {
               "defined": {
@@ -5360,7 +5375,8 @@
           {
             "name": "output_mint",
             "docs": [
-              "Mint of the output token (levercoin mint for s2l, HYUSD mint for l2s)."
+              "Mint of the output token (levercoin mint for `stable_to_lever`, HYUSD",
+              "mint for `lever_to_stable`)."
             ],
             "type": "pubkey"
           },

--- a/hylo-idl/idls/hylo_trigger_orders.json
+++ b/hylo-idl/idls/hylo_trigger_orders.json
@@ -1940,7 +1940,6 @@
         },
         {
           "name": "hylo",
-          "writable": true,
           "pda": {
             "seeds": [
               {
@@ -3263,7 +3262,6 @@
         },
         {
           "name": "hylo",
-          "writable": true,
           "pda": {
             "seeds": [
               {

--- a/hylo-idl/idls/hylo_trigger_orders.json
+++ b/hylo-idl/idls/hylo_trigger_orders.json
@@ -1939,7 +1939,58 @@
           ]
         },
         {
-          "name": "hylo"
+          "name": "hylo",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  104,
+                  121,
+                  108,
+                  111
+                ]
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                245,
+                187,
+                72,
+                160,
+                4,
+                116,
+                48,
+                134,
+                197,
+                164,
+                152,
+                189,
+                233,
+                219,
+                27,
+                124,
+                201,
+                65,
+                103,
+                243,
+                58,
+                82,
+                140,
+                90,
+                13,
+                150,
+                83,
+                40,
+                223,
+                158,
+                124,
+                33
+              ]
+            }
+          }
         },
         {
           "name": "exo_pair",
@@ -2639,7 +2690,57 @@
         },
         {
           "name": "hylo",
-          "writable": true
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  104,
+                  121,
+                  108,
+                  111
+                ]
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                245,
+                187,
+                72,
+                160,
+                4,
+                116,
+                48,
+                134,
+                197,
+                164,
+                152,
+                189,
+                233,
+                219,
+                27,
+                124,
+                201,
+                65,
+                103,
+                243,
+                58,
+                82,
+                140,
+                90,
+                13,
+                150,
+                83,
+                40,
+                223,
+                158,
+                124,
+                33
+              ]
+            }
+          }
         },
         {
           "name": "sol_usd_pyth_feed"
@@ -2711,7 +2812,57 @@
         },
         {
           "name": "xsol_mint",
-          "writable": true
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  120,
+                  83,
+                  79,
+                  76
+                ]
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                245,
+                187,
+                72,
+                160,
+                4,
+                116,
+                48,
+                134,
+                197,
+                164,
+                152,
+                189,
+                233,
+                219,
+                27,
+                124,
+                201,
+                65,
+                103,
+                243,
+                58,
+                82,
+                140,
+                90,
+                13,
+                150,
+                83,
+                40,
+                223,
+                158,
+                124,
+                33
+              ]
+            }
+          }
         },
         {
           "name": "levercoin_auth"
@@ -3111,7 +3262,58 @@
           ]
         },
         {
-          "name": "hylo"
+          "name": "hylo",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  104,
+                  121,
+                  108,
+                  111
+                ]
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                245,
+                187,
+                72,
+                160,
+                4,
+                116,
+                48,
+                134,
+                197,
+                164,
+                152,
+                189,
+                233,
+                219,
+                27,
+                124,
+                201,
+                65,
+                103,
+                243,
+                58,
+                82,
+                140,
+                90,
+                13,
+                150,
+                83,
+                40,
+                223,
+                158,
+                124,
+                33
+              ]
+            }
+          }
         },
         {
           "name": "exo_pair",
@@ -3811,7 +4013,57 @@
         },
         {
           "name": "hylo",
-          "writable": true
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  104,
+                  121,
+                  108,
+                  111
+                ]
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                245,
+                187,
+                72,
+                160,
+                4,
+                116,
+                48,
+                134,
+                197,
+                164,
+                152,
+                189,
+                233,
+                219,
+                27,
+                124,
+                201,
+                65,
+                103,
+                243,
+                58,
+                82,
+                140,
+                90,
+                13,
+                150,
+                83,
+                40,
+                223,
+                158,
+                124,
+                33
+              ]
+            }
+          }
         },
         {
           "name": "sol_usd_pyth_feed"
@@ -3883,7 +4135,57 @@
         },
         {
           "name": "xsol_mint",
-          "writable": true
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  120,
+                  83,
+                  79,
+                  76
+                ]
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                245,
+                187,
+                72,
+                160,
+                4,
+                116,
+                48,
+                134,
+                197,
+                164,
+                152,
+                189,
+                233,
+                219,
+                27,
+                124,
+                201,
+                65,
+                103,
+                243,
+                58,
+                82,
+                140,
+                90,
+                13,
+                150,
+                83,
+                40,
+                223,
+                158,
+                124,
+                33
+              ]
+            }
+          }
         },
         {
           "name": "levercoin_auth"
@@ -4378,6 +4680,11 @@
       "code": 6004,
       "name": "InvalidPythPrice",
       "msg": "Invalid Pyth price update account, feed id, or exponent."
+    },
+    {
+      "code": 6005,
+      "name": "TipArithmetic",
+      "msg": "Executor tip arithmetic overflowed the order's lamport balance."
     }
   ],
   "types": [
@@ -4412,8 +4719,8 @@
       "name": "ConvertDirection",
       "docs": [
         "Direction of the underlying Hylo convert ix the trigger order will fire.",
-        "`StableToLever` burns HYUSD to mint levercoin (the v1 direction).",
-        "`LeverToStable` burns levercoin to mint HYUSD (v1.1 addition)."
+        "`StableToLever` burns HYUSD to mint levercoin; `LeverToStable` burns",
+        "levercoin to mint HYUSD."
       ],
       "type": {
         "kind": "enum",

--- a/hylo-idl/idls/hylo_trigger_orders_shadow.json
+++ b/hylo-idl/idls/hylo_trigger_orders_shadow.json
@@ -5492,18 +5492,6 @@
           {
             "name": "bump",
             "type": "u8"
-          },
-          {
-            "name": "_reserved",
-            "docs": [
-              "Reserved for forward-compatible field additions without a migration."
-            ],
-            "type": {
-              "array": [
-                "u8",
-                64
-              ]
-            }
           }
         ]
       }

--- a/hylo-idl/idls/hylo_trigger_orders_shadow.json
+++ b/hylo-idl/idls/hylo_trigger_orders_shadow.json
@@ -8,16 +8,16 @@
   },
   "instructions": [
     {
-      "name": "cancel_order_l2s_exo",
+      "name": "cancel_order_lever_to_stable_exo",
       "discriminator": [
-        61,
-        165,
-        75,
-        198,
-        91,
-        170,
-        235,
-        153
+        47,
+        127,
+        17,
+        226,
+        125,
+        19,
+        22,
+        80
       ],
       "accounts": [
         {
@@ -239,21 +239,21 @@
       "args": [],
       "returns": {
         "defined": {
-          "name": "TriggerOrderCancelled"
+          "name": "TriggerOrderCancelledEvent"
         }
       }
     },
     {
-      "name": "cancel_order_l2s_lst",
+      "name": "cancel_order_lever_to_stable_lst",
       "discriminator": [
-        121,
-        201,
-        137,
-        113,
-        147,
-        216,
-        109,
-        177
+        68,
+        60,
+        120,
+        236,
+        126,
+        232,
+        1,
+        22
       ],
       "accounts": [
         {
@@ -455,21 +455,21 @@
       "args": [],
       "returns": {
         "defined": {
-          "name": "TriggerOrderCancelled"
+          "name": "TriggerOrderCancelledEvent"
         }
       }
     },
     {
-      "name": "cancel_order_s2l",
+      "name": "cancel_order_stable_to_lever",
       "discriminator": [
-        85,
-        20,
-        75,
-        12,
-        198,
-        159,
-        196,
-        50
+        45,
+        2,
+        38,
+        191,
+        74,
+        153,
+        31,
+        179
       ],
       "accounts": [
         {
@@ -672,21 +672,21 @@
       "args": [],
       "returns": {
         "defined": {
-          "name": "TriggerOrderCancelled"
+          "name": "TriggerOrderCancelledEvent"
         }
       }
     },
     {
-      "name": "create_order_l2s_exo",
+      "name": "create_order_lever_to_stable_exo",
       "discriminator": [
-        145,
-        7,
-        163,
-        2,
-        20,
-        124,
-        128,
-        146
+        18,
+        5,
+        47,
+        137,
+        57,
+        87,
+        9,
+        108
       ],
       "accounts": [
         {
@@ -923,8 +923,9 @@
             "above), so a malformed mint creates a PDA at an address unique to that",
             "owner/nonce/mint triple. No collision risk with other orders.",
             "2. Only the owner is harmed by an unfillable order — their levercoin goes",
-            "into a PDA they alone can drain via `cancel_order_l2s_exo`. There's no",
-            "path for an attacker to lock anyone else's funds via this vector.",
+            "into a PDA they alone can drain via",
+            "`cancel_order_lever_to_stable_exo`. There's no path for an attacker to",
+            "lock anyone else's funds via this vector.",
             "3. The cancel path doesn't read `ExoPair`, `Hylo`, or any pair-specific",
             "state. So even if Hylo deprecates this collateral, the owner can",
             "always recover. Funds-recoverability is structural, not policy.",
@@ -1011,21 +1012,21 @@
       ],
       "returns": {
         "defined": {
-          "name": "TriggerOrderCreated"
+          "name": "TriggerOrderCreatedEvent"
         }
       }
     },
     {
-      "name": "create_order_l2s_lst",
+      "name": "create_order_lever_to_stable_lst",
       "discriminator": [
-        217,
-        157,
-        106,
-        121,
-        230,
-        232,
-        238,
-        73
+        169,
+        244,
+        48,
+        59,
+        91,
+        86,
+        47,
+        4
       ],
       "accounts": [
         {
@@ -1295,21 +1296,21 @@
       ],
       "returns": {
         "defined": {
-          "name": "TriggerOrderCreated"
+          "name": "TriggerOrderCreatedEvent"
         }
       }
     },
     {
-      "name": "create_order_s2l_exo",
+      "name": "create_order_stable_to_lever_exo",
       "discriminator": [
+        64,
+        253,
+        226,
+        234,
         102,
-        197,
-        120,
-        21,
-        57,
-        139,
-        195,
-        202
+        182,
+        158,
+        44
       ],
       "accounts": [
         {
@@ -1534,8 +1535,9 @@
             "above), so a malformed mint creates a PDA at an address unique to that",
             "owner/nonce/mint triple. No collision risk with other orders.",
             "2. Only the owner is harmed by an unfillable order — their HYUSD goes",
-            "into a PDA they alone can drain via `cancel_order_s2l`. There's no",
-            "path for an attacker to lock anyone else's funds via this vector.",
+            "into a PDA they alone can drain via `cancel_order_stable_to_lever`.",
+            "There's no path for an attacker to lock anyone else's funds via this",
+            "vector.",
             "3. The cancel path doesn't read `ExoPair`, `Hylo`, or any pair-specific",
             "state. So even if Hylo deprecates this collateral, the owner can",
             "always recover. Funds-recoverability is structural, not policy.",
@@ -1622,21 +1624,21 @@
       ],
       "returns": {
         "defined": {
-          "name": "TriggerOrderCreated"
+          "name": "TriggerOrderCreatedEvent"
         }
       }
     },
     {
-      "name": "create_order_s2l_lst",
+      "name": "create_order_stable_to_lever_lst",
       "discriminator": [
-        1,
-        195,
-        39,
-        158,
-        147,
-        192,
-        10,
-        101
+        44,
+        239,
+        230,
+        43,
+        167,
+        109,
+        159,
+        75
       ],
       "accounts": [
         {
@@ -1907,21 +1909,21 @@
       ],
       "returns": {
         "defined": {
-          "name": "TriggerOrderCreated"
+          "name": "TriggerOrderCreatedEvent"
         }
       }
     },
     {
-      "name": "execute_order_l2s_exo",
+      "name": "execute_order_lever_to_stable_exo",
       "discriminator": [
-        112,
-        175,
-        205,
-        216,
-        129,
-        95,
-        184,
-        153
+        37,
+        208,
+        145,
+        18,
+        1,
+        120,
+        209,
+        189
       ],
       "accounts": [
         {
@@ -2606,21 +2608,21 @@
       "args": [],
       "returns": {
         "defined": {
-          "name": "TriggerOrderFilled"
+          "name": "TriggerOrderFilledEvent"
         }
       }
     },
     {
-      "name": "execute_order_l2s_lst",
+      "name": "execute_order_lever_to_stable_lst",
       "discriminator": [
-        96,
-        37,
-        224,
-        31,
-        190,
-        139,
-        223,
-        0
+        148,
+        194,
+        232,
+        208,
+        165,
+        164,
+        221,
+        71
       ],
       "accounts": [
         {
@@ -3079,21 +3081,21 @@
       "args": [],
       "returns": {
         "defined": {
-          "name": "TriggerOrderFilled"
+          "name": "TriggerOrderFilledEvent"
         }
       }
     },
     {
-      "name": "execute_order_s2l_exo",
+      "name": "execute_order_stable_to_lever_exo",
       "discriminator": [
-        29,
-        184,
-        147,
-        164,
-        106,
-        9,
-        121,
-        21
+        78,
+        24,
+        242,
+        4,
+        17,
+        60,
+        133,
+        89
       ],
       "accounts": [
         {
@@ -3778,21 +3780,21 @@
       "args": [],
       "returns": {
         "defined": {
-          "name": "TriggerOrderFilled"
+          "name": "TriggerOrderFilledEvent"
         }
       }
     },
     {
-      "name": "execute_order_s2l_lst",
+      "name": "execute_order_stable_to_lever_lst",
       "discriminator": [
-        26,
-        104,
-        100,
-        203,
-        82,
-        5,
-        112,
-        58
+        225,
+        97,
+        249,
+        74,
+        99,
+        214,
+        130,
+        114
       ],
       "accounts": [
         {
@@ -4251,7 +4253,7 @@
       "args": [],
       "returns": {
         "defined": {
-          "name": "TriggerOrderFilled"
+          "name": "TriggerOrderFilledEvent"
         }
       }
     }
@@ -4312,42 +4314,42 @@
   ],
   "events": [
     {
-      "name": "TriggerOrderCancelled",
+      "name": "TriggerOrderCancelledEvent",
       "discriminator": [
-        255,
-        151,
-        206,
-        140,
-        98,
-        153,
-        223,
-        121
-      ]
-    },
-    {
-      "name": "TriggerOrderCreated",
-      "discriminator": [
-        90,
-        78,
+        178,
+        127,
         39,
-        34,
-        130,
-        168,
-        79,
-        55
+        234,
+        87,
+        193,
+        7,
+        119
       ]
     },
     {
-      "name": "TriggerOrderFilled",
+      "name": "TriggerOrderCreatedEvent",
       "discriminator": [
-        124,
-        156,
-        201,
-        86,
-        158,
-        86,
-        183,
-        212
+        231,
+        191,
+        133,
+        0,
+        130,
+        0,
+        198,
+        83
+      ]
+    },
+    {
+      "name": "TriggerOrderFilledEvent",
+      "discriminator": [
+        72,
+        131,
+        117,
+        214,
+        75,
+        219,
+        32,
+        36
       ]
     }
   ],
@@ -4355,27 +4357,27 @@
     {
       "code": 6000,
       "name": "AmountTooSmall",
-      "msg": "escrow_amount must be > 0"
+      "msg": "Escrow amount must be greater than zero."
     },
     {
       "code": 6001,
       "name": "AccountMismatch",
-      "msg": "account does not match the order's pair target"
+      "msg": "Account does not match the order's pair target."
     },
     {
       "code": 6002,
       "name": "TriggerNotMet",
-      "msg": "price condition not met"
+      "msg": "Price condition not met."
     },
     {
       "code": 6003,
       "name": "Unauthorized",
-      "msg": "signer is not the order owner"
+      "msg": "Signer is not the order owner."
     },
     {
       "code": 6004,
       "name": "InvalidPythPrice",
-      "msg": "invalid pyth price update account, feed id, or expo"
+      "msg": "Invalid Pyth price update account, feed id, or exponent."
     }
   ],
   "types": [
@@ -5125,7 +5127,8 @@
           {
             "name": "convert_direction",
             "docs": [
-              "Direction of the Hylo convert ix this order will fire (s2l or l2s)."
+              "Direction of the Hylo convert ix this order will fire",
+              "(`stable_to_lever` or `lever_to_stable`)."
             ],
             "type": {
               "defined": {
@@ -5145,7 +5148,8 @@
             "name": "escrow_amount",
             "docs": [
               "Amount escrowed in the order's escrow vault. Unit depends on",
-              "`convert_direction`: HYUSD for s2l; xSOL or per-EXO levercoin for l2s."
+              "`convert_direction`: HYUSD for `stable_to_lever`; xSOL or per-EXO",
+              "levercoin for `lever_to_stable`."
             ],
             "type": "u64"
           },
@@ -5181,15 +5185,26 @@
           {
             "name": "bump",
             "type": "u8"
+          },
+          {
+            "name": "_reserved",
+            "docs": [
+              "Reserved for forward-compatible field additions without a migration."
+            ],
+            "type": {
+              "array": [
+                "u8",
+                64
+              ]
+            }
           }
         ]
       }
     },
     {
-      "name": "TriggerOrderCancelled",
+      "name": "TriggerOrderCancelledEvent",
       "docs": [
-        "Emitted at the end of `cancel_order_{s2l,l2s_lst,l2s_exo}` after the",
-        "refund completes."
+        "Emitted at the end of `cancel_order_*` after the refund completes."
       ],
       "type": {
         "kind": "struct",
@@ -5230,10 +5245,9 @@
       }
     },
     {
-      "name": "TriggerOrderCreated",
+      "name": "TriggerOrderCreatedEvent",
       "docs": [
-        "Emitted at the end of `create_order_{s2l,l2s}_{lst,exo}` after state",
-        "mutations succeed."
+        "Emitted at the end of `create_order_*` after state mutations succeed."
       ],
       "type": {
         "kind": "struct",
@@ -5269,7 +5283,8 @@
           {
             "name": "escrow_amount",
             "docs": [
-              "Amount escrowed (HYUSD for s2l, levercoin for l2s)."
+              "Amount escrowed (HYUSD for `stable_to_lever`, levercoin for",
+              "`lever_to_stable`)."
             ],
             "type": "u64"
           },
@@ -5297,11 +5312,11 @@
       }
     },
     {
-      "name": "TriggerOrderFilled",
+      "name": "TriggerOrderFilledEvent",
       "docs": [
-        "Emitted at the end of `execute_order_{s2l,l2s}_{lst,exo}` after the order",
-        "fills. `output_received` mirrors Hylo's convert event field",
-        "(`UFixValue64`) verbatim."
+        "Emitted at the end of `execute_order_*` after the order fills.",
+        "`output_received` mirrors Hylo's convert event field (`UFixValue64`)",
+        "verbatim."
       ],
       "type": {
         "kind": "struct",
@@ -5348,8 +5363,8 @@
           {
             "name": "output_received",
             "docs": [
-              "Amount minted to the owner's output ATA (levercoin for s2l, HYUSD for",
-              "l2s)."
+              "Amount minted to the owner's output ATA (levercoin for",
+              "`stable_to_lever`, HYUSD for `lever_to_stable`)."
             ],
             "type": {
               "defined": {
@@ -5360,7 +5375,8 @@
           {
             "name": "output_mint",
             "docs": [
-              "Mint of the output token (levercoin mint for s2l, HYUSD mint for l2s)."
+              "Mint of the output token (levercoin mint for `stable_to_lever`, HYUSD",
+              "mint for `lever_to_stable`)."
             ],
             "type": "pubkey"
           },

--- a/hylo-idl/idls/hylo_trigger_orders_shadow.json
+++ b/hylo-idl/idls/hylo_trigger_orders_shadow.json
@@ -1940,7 +1940,6 @@
         },
         {
           "name": "hylo",
-          "writable": true,
           "pda": {
             "seeds": [
               {
@@ -3263,7 +3262,6 @@
         },
         {
           "name": "hylo",
-          "writable": true,
           "pda": {
             "seeds": [
               {

--- a/hylo-idl/idls/hylo_trigger_orders_shadow.json
+++ b/hylo-idl/idls/hylo_trigger_orders_shadow.json
@@ -1939,7 +1939,58 @@
           ]
         },
         {
-          "name": "hylo"
+          "name": "hylo",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  104,
+                  121,
+                  108,
+                  111
+                ]
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                245,
+                187,
+                72,
+                160,
+                4,
+                116,
+                48,
+                134,
+                197,
+                164,
+                152,
+                189,
+                233,
+                219,
+                27,
+                124,
+                201,
+                65,
+                103,
+                243,
+                58,
+                82,
+                140,
+                90,
+                13,
+                150,
+                83,
+                40,
+                223,
+                158,
+                124,
+                33
+              ]
+            }
+          }
         },
         {
           "name": "exo_pair",
@@ -2639,7 +2690,57 @@
         },
         {
           "name": "hylo",
-          "writable": true
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  104,
+                  121,
+                  108,
+                  111
+                ]
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                245,
+                187,
+                72,
+                160,
+                4,
+                116,
+                48,
+                134,
+                197,
+                164,
+                152,
+                189,
+                233,
+                219,
+                27,
+                124,
+                201,
+                65,
+                103,
+                243,
+                58,
+                82,
+                140,
+                90,
+                13,
+                150,
+                83,
+                40,
+                223,
+                158,
+                124,
+                33
+              ]
+            }
+          }
         },
         {
           "name": "sol_usd_pyth_feed"
@@ -2711,7 +2812,57 @@
         },
         {
           "name": "xsol_mint",
-          "writable": true
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  120,
+                  83,
+                  79,
+                  76
+                ]
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                245,
+                187,
+                72,
+                160,
+                4,
+                116,
+                48,
+                134,
+                197,
+                164,
+                152,
+                189,
+                233,
+                219,
+                27,
+                124,
+                201,
+                65,
+                103,
+                243,
+                58,
+                82,
+                140,
+                90,
+                13,
+                150,
+                83,
+                40,
+                223,
+                158,
+                124,
+                33
+              ]
+            }
+          }
         },
         {
           "name": "levercoin_auth"
@@ -3111,7 +3262,58 @@
           ]
         },
         {
-          "name": "hylo"
+          "name": "hylo",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  104,
+                  121,
+                  108,
+                  111
+                ]
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                245,
+                187,
+                72,
+                160,
+                4,
+                116,
+                48,
+                134,
+                197,
+                164,
+                152,
+                189,
+                233,
+                219,
+                27,
+                124,
+                201,
+                65,
+                103,
+                243,
+                58,
+                82,
+                140,
+                90,
+                13,
+                150,
+                83,
+                40,
+                223,
+                158,
+                124,
+                33
+              ]
+            }
+          }
         },
         {
           "name": "exo_pair",
@@ -3811,7 +4013,57 @@
         },
         {
           "name": "hylo",
-          "writable": true
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  104,
+                  121,
+                  108,
+                  111
+                ]
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                245,
+                187,
+                72,
+                160,
+                4,
+                116,
+                48,
+                134,
+                197,
+                164,
+                152,
+                189,
+                233,
+                219,
+                27,
+                124,
+                201,
+                65,
+                103,
+                243,
+                58,
+                82,
+                140,
+                90,
+                13,
+                150,
+                83,
+                40,
+                223,
+                158,
+                124,
+                33
+              ]
+            }
+          }
         },
         {
           "name": "sol_usd_pyth_feed"
@@ -3883,7 +4135,57 @@
         },
         {
           "name": "xsol_mint",
-          "writable": true
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  120,
+                  83,
+                  79,
+                  76
+                ]
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                245,
+                187,
+                72,
+                160,
+                4,
+                116,
+                48,
+                134,
+                197,
+                164,
+                152,
+                189,
+                233,
+                219,
+                27,
+                124,
+                201,
+                65,
+                103,
+                243,
+                58,
+                82,
+                140,
+                90,
+                13,
+                150,
+                83,
+                40,
+                223,
+                158,
+                124,
+                33
+              ]
+            }
+          }
         },
         {
           "name": "levercoin_auth"
@@ -4378,6 +4680,11 @@
       "code": 6004,
       "name": "InvalidPythPrice",
       "msg": "Invalid Pyth price update account, feed id, or exponent."
+    },
+    {
+      "code": 6005,
+      "name": "TipArithmetic",
+      "msg": "Executor tip arithmetic overflowed the order's lamport balance."
     }
   ],
   "types": [
@@ -4412,8 +4719,8 @@
       "name": "ConvertDirection",
       "docs": [
         "Direction of the underlying Hylo convert ix the trigger order will fire.",
-        "`StableToLever` burns HYUSD to mint levercoin (the v1 direction).",
-        "`LeverToStable` burns levercoin to mint HYUSD (v1.1 addition)."
+        "`StableToLever` burns HYUSD to mint levercoin; `LeverToStable` burns",
+        "levercoin to mint HYUSD."
       ],
       "type": {
         "kind": "enum",

--- a/hylo-idl/src/account_builders/trigger_orders.rs
+++ b/hylo-idl/src/account_builders/trigger_orders.rs
@@ -8,16 +8,22 @@ use anchor_spl::{associated_token, token};
 use crate::exchange::accounts::{ExoPair, Hylo};
 use crate::tokens::{TokenMint, HYUSD, XSOL};
 use crate::trigger_orders::client::accounts::{
-  CancelOrderL2sExo, CancelOrderL2sLst, CancelOrderS2l, CreateOrderL2sExo,
-  CreateOrderL2sLst, CreateOrderS2lExo, CreateOrderS2lLst, ExecuteOrderL2sExo,
-  ExecuteOrderL2sLst, ExecuteOrderS2lExo, ExecuteOrderS2lLst,
+  CancelOrderLeverToStableExo, CancelOrderLeverToStableLst,
+  CancelOrderStableToLever, CreateOrderLeverToStableExo,
+  CreateOrderLeverToStableLst, CreateOrderStableToLeverExo,
+  CreateOrderStableToLeverLst, ExecuteOrderLeverToStableExo,
+  ExecuteOrderLeverToStableLst, ExecuteOrderStableToLeverExo,
+  ExecuteOrderStableToLeverLst,
 };
 use crate::{pda, trigger_orders};
 
 /// Builds account context for creating a stable-to-lever order (LST).
 #[must_use]
-pub fn create_order_s2l_lst(owner: Pubkey, order: Pubkey) -> CreateOrderS2lLst {
-  CreateOrderS2lLst {
+pub fn create_order_stable_to_lever_lst(
+  owner: Pubkey,
+  order: Pubkey,
+) -> CreateOrderStableToLeverLst {
+  CreateOrderStableToLeverLst {
     owner,
     order,
     order_hyusd_vault: pda::ata(order, HYUSD::MINT),
@@ -34,12 +40,12 @@ pub fn create_order_s2l_lst(owner: Pubkey, order: Pubkey) -> CreateOrderS2lLst {
 
 /// Builds account context for creating a stable-to-lever order (EXO).
 #[must_use]
-pub fn create_order_s2l_exo(
+pub fn create_order_stable_to_lever_exo(
   owner: Pubkey,
   order: Pubkey,
   collateral_mint: Pubkey,
-) -> CreateOrderS2lExo {
-  CreateOrderS2lExo {
+) -> CreateOrderStableToLeverExo {
+  CreateOrderStableToLeverExo {
     owner,
     order,
     order_hyusd_vault: pda::ata(order, HYUSD::MINT),
@@ -57,8 +63,11 @@ pub fn create_order_s2l_exo(
 
 /// Builds account context for creating a lever-to-stable order (LST).
 #[must_use]
-pub fn create_order_l2s_lst(owner: Pubkey, order: Pubkey) -> CreateOrderL2sLst {
-  CreateOrderL2sLst {
+pub fn create_order_lever_to_stable_lst(
+  owner: Pubkey,
+  order: Pubkey,
+) -> CreateOrderLeverToStableLst {
+  CreateOrderLeverToStableLst {
     owner,
     order,
     order_xsol_vault: pda::ata(order, XSOL::MINT),
@@ -75,13 +84,13 @@ pub fn create_order_l2s_lst(owner: Pubkey, order: Pubkey) -> CreateOrderL2sLst {
 
 /// Builds account context for creating a lever-to-stable order (EXO).
 #[must_use]
-pub fn create_order_l2s_exo(
+pub fn create_order_lever_to_stable_exo(
   owner: Pubkey,
   order: Pubkey,
   collateral_mint: Pubkey,
-) -> CreateOrderL2sExo {
+) -> CreateOrderLeverToStableExo {
   let levercoin_mint = pda::exo_levercoin_mint(collateral_mint);
-  CreateOrderL2sExo {
+  CreateOrderLeverToStableExo {
     owner,
     order,
     order_levercoin_vault: pda::ata(order, levercoin_mint),
@@ -99,13 +108,13 @@ pub fn create_order_l2s_exo(
 
 /// Builds account context for executing a stable-to-lever order (LST).
 #[must_use]
-pub fn execute_order_s2l_lst(
+pub fn execute_order_stable_to_lever_lst(
   executor: Pubkey,
   owner: Pubkey,
   order: Pubkey,
   hylo: &Hylo,
-) -> ExecuteOrderS2lLst {
-  ExecuteOrderS2lLst {
+) -> ExecuteOrderStableToLeverLst {
+  ExecuteOrderStableToLeverLst {
     executor,
     owner,
     hylo: pda::HYLO,
@@ -132,13 +141,13 @@ pub fn execute_order_s2l_lst(
 
 /// Builds account context for executing a lever-to-stable order (LST).
 #[must_use]
-pub fn execute_order_l2s_lst(
+pub fn execute_order_lever_to_stable_lst(
   executor: Pubkey,
   owner: Pubkey,
   order: Pubkey,
   hylo: &Hylo,
-) -> ExecuteOrderL2sLst {
-  ExecuteOrderL2sLst {
+) -> ExecuteOrderLeverToStableLst {
+  ExecuteOrderLeverToStableLst {
     executor,
     owner,
     hylo: pda::HYLO,
@@ -168,17 +177,17 @@ pub fn execute_order_l2s_lst(
 /// `_hylo` is accepted for signature symmetry with the LST builders; the EXO
 /// CPI uses the per-pair `exo_pair.oracle` rather than the Hylo SOL/USD oracle.
 #[must_use]
-pub fn execute_order_s2l_exo(
+pub fn execute_order_stable_to_lever_exo(
   executor: Pubkey,
   owner: Pubkey,
   order: Pubkey,
   collateral_mint: Pubkey,
   _hylo: &Hylo,
   exo_pair: &ExoPair,
-) -> ExecuteOrderS2lExo {
+) -> ExecuteOrderStableToLeverExo {
   let levercoin_mint = pda::exo_levercoin_mint(collateral_mint);
   let vault_auth = pda::exo_vault_auth(collateral_mint);
-  ExecuteOrderS2lExo {
+  ExecuteOrderStableToLeverExo {
     executor,
     owner,
     hylo: pda::HYLO,
@@ -212,17 +221,17 @@ pub fn execute_order_s2l_exo(
 /// `_hylo` is accepted for signature symmetry with the LST builders; the EXO
 /// CPI uses the per-pair `exo_pair.oracle` rather than the Hylo SOL/USD oracle.
 #[must_use]
-pub fn execute_order_l2s_exo(
+pub fn execute_order_lever_to_stable_exo(
   executor: Pubkey,
   owner: Pubkey,
   order: Pubkey,
   collateral_mint: Pubkey,
   _hylo: &Hylo,
   exo_pair: &ExoPair,
-) -> ExecuteOrderL2sExo {
+) -> ExecuteOrderLeverToStableExo {
   let levercoin_mint = pda::exo_levercoin_mint(collateral_mint);
   let vault_auth = pda::exo_vault_auth(collateral_mint);
-  ExecuteOrderL2sExo {
+  ExecuteOrderLeverToStableExo {
     executor,
     owner,
     hylo: pda::HYLO,
@@ -253,11 +262,15 @@ pub fn execute_order_l2s_exo(
 
 /// Builds account context for cancelling a stable-to-lever order.
 ///
-/// Handles both LST and EXO s2l orders: the s2l escrow is always HYUSD
-/// regardless of the order's lever target, so no collateral mint is needed.
+/// Handles both LST and EXO stable-to-lever orders: the stable-to-lever
+/// escrow is always HYUSD regardless of the order's lever target, so no
+/// collateral mint is needed.
 #[must_use]
-pub fn cancel_order_s2l(owner: Pubkey, order: Pubkey) -> CancelOrderS2l {
-  CancelOrderS2l {
+pub fn cancel_order_stable_to_lever(
+  owner: Pubkey,
+  order: Pubkey,
+) -> CancelOrderStableToLever {
+  CancelOrderStableToLever {
     owner,
     order,
     order_hyusd_vault: pda::ata(order, HYUSD::MINT),
@@ -271,8 +284,11 @@ pub fn cancel_order_s2l(owner: Pubkey, order: Pubkey) -> CancelOrderS2l {
 
 /// Builds account context for cancelling a lever-to-stable order (LST).
 #[must_use]
-pub fn cancel_order_l2s_lst(owner: Pubkey, order: Pubkey) -> CancelOrderL2sLst {
-  CancelOrderL2sLst {
+pub fn cancel_order_lever_to_stable_lst(
+  owner: Pubkey,
+  order: Pubkey,
+) -> CancelOrderLeverToStableLst {
+  CancelOrderLeverToStableLst {
     owner,
     order,
     order_xsol_vault: pda::ata(order, XSOL::MINT),
@@ -286,13 +302,13 @@ pub fn cancel_order_l2s_lst(owner: Pubkey, order: Pubkey) -> CancelOrderL2sLst {
 
 /// Builds account context for cancelling a lever-to-stable order (EXO).
 #[must_use]
-pub fn cancel_order_l2s_exo(
+pub fn cancel_order_lever_to_stable_exo(
   owner: Pubkey,
   order: Pubkey,
   collateral_mint: Pubkey,
-) -> CancelOrderL2sExo {
+) -> CancelOrderLeverToStableExo {
   let levercoin_mint = pda::exo_levercoin_mint(collateral_mint);
-  CancelOrderL2sExo {
+  CancelOrderLeverToStableExo {
     owner,
     order,
     order_levercoin_vault: pda::ata(order, levercoin_mint),
@@ -347,7 +363,7 @@ mod tests {
   }
 
   #[test]
-  fn execute_order_s2l_lst_threads_hylo_oracle() {
+  fn execute_order_stable_to_lever_lst_threads_hylo_oracle() {
     let executor = Pubkey::new_unique();
     let owner = Pubkey::new_unique();
     let order = Pubkey::new_unique();
@@ -355,7 +371,7 @@ mod tests {
     let oracle = Pubkey::new_unique();
     hylo.sol_usd_oracle = oracle;
 
-    let a = execute_order_s2l_lst(executor, owner, order, &hylo);
+    let a = execute_order_stable_to_lever_lst(executor, owner, order, &hylo);
 
     assert_eq!(a.executor, executor);
     assert_eq!(a.owner, owner);
@@ -384,7 +400,7 @@ mod tests {
   }
 
   #[test]
-  fn execute_order_l2s_lst_threads_hylo_oracle() {
+  fn execute_order_lever_to_stable_lst_threads_hylo_oracle() {
     let executor = Pubkey::new_unique();
     let owner = Pubkey::new_unique();
     let order = Pubkey::new_unique();
@@ -392,7 +408,7 @@ mod tests {
     let oracle = Pubkey::new_unique();
     hylo.sol_usd_oracle = oracle;
 
-    let a = execute_order_l2s_lst(executor, owner, order, &hylo);
+    let a = execute_order_lever_to_stable_lst(executor, owner, order, &hylo);
 
     assert_eq!(a.executor, executor);
     assert_eq!(a.owner, owner);
@@ -421,7 +437,7 @@ mod tests {
   }
 
   #[test]
-  fn execute_order_s2l_exo_threads_exo_oracle() {
+  fn execute_order_stable_to_lever_exo_threads_exo_oracle() {
     let executor = Pubkey::new_unique();
     let owner = Pubkey::new_unique();
     let order = Pubkey::new_unique();
@@ -433,7 +449,7 @@ mod tests {
     let levercoin_mint = pda::exo_levercoin_mint(collateral_mint);
     let vault_auth = pda::exo_vault_auth(collateral_mint);
 
-    let a = execute_order_s2l_exo(
+    let a = execute_order_stable_to_lever_exo(
       executor,
       owner,
       order,
@@ -473,7 +489,7 @@ mod tests {
   }
 
   #[test]
-  fn execute_order_l2s_exo_threads_exo_oracle() {
+  fn execute_order_lever_to_stable_exo_threads_exo_oracle() {
     let executor = Pubkey::new_unique();
     let owner = Pubkey::new_unique();
     let order = Pubkey::new_unique();
@@ -485,7 +501,7 @@ mod tests {
     let levercoin_mint = pda::exo_levercoin_mint(collateral_mint);
     let vault_auth = pda::exo_vault_auth(collateral_mint);
 
-    let a = execute_order_l2s_exo(
+    let a = execute_order_lever_to_stable_exo(
       executor,
       owner,
       order,
@@ -525,10 +541,10 @@ mod tests {
   }
 
   #[test]
-  fn create_order_s2l_lst_builds_correct_pdas() {
+  fn create_order_stable_to_lever_lst_builds_correct_pdas() {
     let owner = Pubkey::new_unique();
     let order = Pubkey::new_unique();
-    let a = create_order_s2l_lst(owner, order);
+    let a = create_order_stable_to_lever_lst(owner, order);
 
     assert_eq!(a.owner, owner);
     assert_eq!(a.order, order);
@@ -544,11 +560,11 @@ mod tests {
   }
 
   #[test]
-  fn create_order_s2l_exo_builds_correct_pdas() {
+  fn create_order_stable_to_lever_exo_builds_correct_pdas() {
     let owner = Pubkey::new_unique();
     let order = Pubkey::new_unique();
     let collateral_mint = Pubkey::new_unique();
-    let a = create_order_s2l_exo(owner, order, collateral_mint);
+    let a = create_order_stable_to_lever_exo(owner, order, collateral_mint);
 
     assert_eq!(a.owner, owner);
     assert_eq!(a.order, order);
@@ -565,10 +581,10 @@ mod tests {
   }
 
   #[test]
-  fn create_order_l2s_lst_builds_correct_pdas() {
+  fn create_order_lever_to_stable_lst_builds_correct_pdas() {
     let owner = Pubkey::new_unique();
     let order = Pubkey::new_unique();
-    let a = create_order_l2s_lst(owner, order);
+    let a = create_order_lever_to_stable_lst(owner, order);
 
     assert_eq!(a.owner, owner);
     assert_eq!(a.order, order);
@@ -584,12 +600,12 @@ mod tests {
   }
 
   #[test]
-  fn create_order_l2s_exo_builds_correct_pdas() {
+  fn create_order_lever_to_stable_exo_builds_correct_pdas() {
     let owner = Pubkey::new_unique();
     let order = Pubkey::new_unique();
     let collateral_mint = Pubkey::new_unique();
     let levercoin_mint = pda::exo_levercoin_mint(collateral_mint);
-    let a = create_order_l2s_exo(owner, order, collateral_mint);
+    let a = create_order_lever_to_stable_exo(owner, order, collateral_mint);
 
     assert_eq!(a.owner, owner);
     assert_eq!(a.order, order);
@@ -606,10 +622,10 @@ mod tests {
   }
 
   #[test]
-  fn cancel_order_s2l_minimal_fields() {
+  fn cancel_order_stable_to_lever_minimal_fields() {
     let owner = Pubkey::new_unique();
     let order = Pubkey::new_unique();
-    let a = cancel_order_s2l(owner, order);
+    let a = cancel_order_stable_to_lever(owner, order);
     assert_eq!(a.owner, owner);
     assert_eq!(a.order, order);
     assert_eq!(a.order_hyusd_vault, pda::ata(order, HYUSD::MINT));
@@ -621,10 +637,10 @@ mod tests {
   }
 
   #[test]
-  fn cancel_order_l2s_lst_minimal_fields() {
+  fn cancel_order_lever_to_stable_lst_minimal_fields() {
     let owner = Pubkey::new_unique();
     let order = Pubkey::new_unique();
-    let a = cancel_order_l2s_lst(owner, order);
+    let a = cancel_order_lever_to_stable_lst(owner, order);
     assert_eq!(a.owner, owner);
     assert_eq!(a.order, order);
     assert_eq!(a.order_xsol_vault, pda::ata(order, XSOL::MINT));
@@ -636,12 +652,12 @@ mod tests {
   }
 
   #[test]
-  fn cancel_order_l2s_exo_minimal_fields() {
+  fn cancel_order_lever_to_stable_exo_minimal_fields() {
     let owner = Pubkey::new_unique();
     let order = Pubkey::new_unique();
     let collateral_mint = Pubkey::new_unique();
     let levercoin_mint = pda::exo_levercoin_mint(collateral_mint);
-    let a = cancel_order_l2s_exo(owner, order, collateral_mint);
+    let a = cancel_order_lever_to_stable_exo(owner, order, collateral_mint);
     assert_eq!(a.owner, owner);
     assert_eq!(a.order, order);
     assert_eq!(a.order_levercoin_vault, pda::ata(order, levercoin_mint));

--- a/hylo-idl/src/instruction_builders/trigger_orders.rs
+++ b/hylo-idl/src/instruction_builders/trigger_orders.rs
@@ -10,12 +10,13 @@ use crate::trigger_orders::account_builders;
 use crate::trigger_orders::client::args;
 
 #[must_use]
-pub fn create_order_s2l_lst(
+pub fn create_order_stable_to_lever_lst(
   owner: Pubkey,
   order: Pubkey,
-  args: &args::CreateOrderS2lLst,
+  args: &args::CreateOrderStableToLeverLst,
 ) -> Instruction {
-  let accounts = account_builders::create_order_s2l_lst(owner, order);
+  let accounts =
+    account_builders::create_order_stable_to_lever_lst(owner, order);
   Instruction {
     program_id: trigger_orders::ID,
     accounts: accounts.to_account_metas(None),
@@ -24,14 +25,17 @@ pub fn create_order_s2l_lst(
 }
 
 #[must_use]
-pub fn create_order_s2l_exo(
+pub fn create_order_stable_to_lever_exo(
   owner: Pubkey,
   order: Pubkey,
   collateral_mint: Pubkey,
-  args: &args::CreateOrderS2lExo,
+  args: &args::CreateOrderStableToLeverExo,
 ) -> Instruction {
-  let accounts =
-    account_builders::create_order_s2l_exo(owner, order, collateral_mint);
+  let accounts = account_builders::create_order_stable_to_lever_exo(
+    owner,
+    order,
+    collateral_mint,
+  );
   Instruction {
     program_id: trigger_orders::ID,
     accounts: accounts.to_account_metas(None),
@@ -40,12 +44,13 @@ pub fn create_order_s2l_exo(
 }
 
 #[must_use]
-pub fn create_order_l2s_lst(
+pub fn create_order_lever_to_stable_lst(
   owner: Pubkey,
   order: Pubkey,
-  args: &args::CreateOrderL2sLst,
+  args: &args::CreateOrderLeverToStableLst,
 ) -> Instruction {
-  let accounts = account_builders::create_order_l2s_lst(owner, order);
+  let accounts =
+    account_builders::create_order_lever_to_stable_lst(owner, order);
   Instruction {
     program_id: trigger_orders::ID,
     accounts: accounts.to_account_metas(None),
@@ -54,14 +59,17 @@ pub fn create_order_l2s_lst(
 }
 
 #[must_use]
-pub fn create_order_l2s_exo(
+pub fn create_order_lever_to_stable_exo(
   owner: Pubkey,
   order: Pubkey,
   collateral_mint: Pubkey,
-  args: &args::CreateOrderL2sExo,
+  args: &args::CreateOrderLeverToStableExo,
 ) -> Instruction {
-  let accounts =
-    account_builders::create_order_l2s_exo(owner, order, collateral_mint);
+  let accounts = account_builders::create_order_lever_to_stable_exo(
+    owner,
+    order,
+    collateral_mint,
+  );
   Instruction {
     program_id: trigger_orders::ID,
     accounts: accounts.to_account_metas(None),
@@ -70,39 +78,41 @@ pub fn create_order_l2s_exo(
 }
 
 #[must_use]
-pub fn execute_order_s2l_lst(
+pub fn execute_order_stable_to_lever_lst(
   executor: Pubkey,
   owner: Pubkey,
   order: Pubkey,
   hylo: &Hylo,
 ) -> Instruction {
-  let accounts =
-    account_builders::execute_order_s2l_lst(executor, owner, order, hylo);
+  let accounts = account_builders::execute_order_stable_to_lever_lst(
+    executor, owner, order, hylo,
+  );
   Instruction {
     program_id: trigger_orders::ID,
     accounts: accounts.to_account_metas(None),
-    data: args::ExecuteOrderS2lLst {}.data(),
+    data: args::ExecuteOrderStableToLeverLst {}.data(),
   }
 }
 
 #[must_use]
-pub fn execute_order_l2s_lst(
+pub fn execute_order_lever_to_stable_lst(
   executor: Pubkey,
   owner: Pubkey,
   order: Pubkey,
   hylo: &Hylo,
 ) -> Instruction {
-  let accounts =
-    account_builders::execute_order_l2s_lst(executor, owner, order, hylo);
+  let accounts = account_builders::execute_order_lever_to_stable_lst(
+    executor, owner, order, hylo,
+  );
   Instruction {
     program_id: trigger_orders::ID,
     accounts: accounts.to_account_metas(None),
-    data: args::ExecuteOrderL2sLst {}.data(),
+    data: args::ExecuteOrderLeverToStableLst {}.data(),
   }
 }
 
 #[must_use]
-pub fn execute_order_s2l_exo(
+pub fn execute_order_stable_to_lever_exo(
   executor: Pubkey,
   owner: Pubkey,
   order: Pubkey,
@@ -110,7 +120,7 @@ pub fn execute_order_s2l_exo(
   hylo: &Hylo,
   exo_pair: &ExoPair,
 ) -> Instruction {
-  let accounts = account_builders::execute_order_s2l_exo(
+  let accounts = account_builders::execute_order_stable_to_lever_exo(
     executor,
     owner,
     order,
@@ -121,12 +131,12 @@ pub fn execute_order_s2l_exo(
   Instruction {
     program_id: trigger_orders::ID,
     accounts: accounts.to_account_metas(None),
-    data: args::ExecuteOrderS2lExo {}.data(),
+    data: args::ExecuteOrderStableToLeverExo {}.data(),
   }
 }
 
 #[must_use]
-pub fn execute_order_l2s_exo(
+pub fn execute_order_lever_to_stable_exo(
   executor: Pubkey,
   owner: Pubkey,
   order: Pubkey,
@@ -134,7 +144,7 @@ pub fn execute_order_l2s_exo(
   hylo: &Hylo,
   exo_pair: &ExoPair,
 ) -> Instruction {
-  let accounts = account_builders::execute_order_l2s_exo(
+  let accounts = account_builders::execute_order_lever_to_stable_exo(
     executor,
     owner,
     order,
@@ -145,17 +155,17 @@ pub fn execute_order_l2s_exo(
   Instruction {
     program_id: trigger_orders::ID,
     accounts: accounts.to_account_metas(None),
-    data: args::ExecuteOrderL2sExo {}.data(),
+    data: args::ExecuteOrderLeverToStableExo {}.data(),
   }
 }
 
 #[must_use]
-pub fn cancel_order_s2l(
+pub fn cancel_order_stable_to_lever(
   owner: Pubkey,
   order: Pubkey,
-  args: &args::CancelOrderS2l,
+  args: &args::CancelOrderStableToLever,
 ) -> Instruction {
-  let accounts = account_builders::cancel_order_s2l(owner, order);
+  let accounts = account_builders::cancel_order_stable_to_lever(owner, order);
   Instruction {
     program_id: trigger_orders::ID,
     accounts: accounts.to_account_metas(None),
@@ -164,12 +174,13 @@ pub fn cancel_order_s2l(
 }
 
 #[must_use]
-pub fn cancel_order_l2s_lst(
+pub fn cancel_order_lever_to_stable_lst(
   owner: Pubkey,
   order: Pubkey,
-  args: &args::CancelOrderL2sLst,
+  args: &args::CancelOrderLeverToStableLst,
 ) -> Instruction {
-  let accounts = account_builders::cancel_order_l2s_lst(owner, order);
+  let accounts =
+    account_builders::cancel_order_lever_to_stable_lst(owner, order);
   Instruction {
     program_id: trigger_orders::ID,
     accounts: accounts.to_account_metas(None),
@@ -178,14 +189,17 @@ pub fn cancel_order_l2s_lst(
 }
 
 #[must_use]
-pub fn cancel_order_l2s_exo(
+pub fn cancel_order_lever_to_stable_exo(
   owner: Pubkey,
   order: Pubkey,
   collateral_mint: Pubkey,
-  args: &args::CancelOrderL2sExo,
+  args: &args::CancelOrderLeverToStableExo,
 ) -> Instruction {
-  let accounts =
-    account_builders::cancel_order_l2s_exo(owner, order, collateral_mint);
+  let accounts = account_builders::cancel_order_lever_to_stable_exo(
+    owner,
+    order,
+    collateral_mint,
+  );
   Instruction {
     program_id: trigger_orders::ID,
     accounts: accounts.to_account_metas(None),
@@ -202,8 +216,8 @@ mod tests {
   };
   use crate::trigger_orders::types::TriggerDirection;
 
-  fn create_args_l2s_lst() -> args::CreateOrderL2sLst {
-    args::CreateOrderL2sLst {
+  fn create_args_lever_to_stable_lst() -> args::CreateOrderLeverToStableLst {
+    args::CreateOrderLeverToStableLst {
       nonce: 42,
       escrow_amount: 1000,
       trigger_price: 100,
@@ -212,8 +226,8 @@ mod tests {
     }
   }
 
-  fn create_args_l2s_exo() -> args::CreateOrderL2sExo {
-    args::CreateOrderL2sExo {
+  fn create_args_lever_to_stable_exo() -> args::CreateOrderLeverToStableExo {
+    args::CreateOrderLeverToStableExo {
       nonce: 42,
       escrow_amount: 1000,
       trigger_price: 100,
@@ -222,8 +236,8 @@ mod tests {
     }
   }
 
-  fn create_args_s2l_exo() -> args::CreateOrderS2lExo {
-    args::CreateOrderS2lExo {
+  fn create_args_stable_to_lever_exo() -> args::CreateOrderStableToLeverExo {
+    args::CreateOrderStableToLeverExo {
       nonce: 42,
       escrow_amount: 1000,
       trigger_price: 100,
@@ -265,17 +279,17 @@ mod tests {
   }
 
   #[test]
-  fn create_order_s2l_lst_returns_well_formed_instruction() {
+  fn create_order_stable_to_lever_lst_returns_well_formed_instruction() {
     let owner = Pubkey::new_unique();
     let order = Pubkey::new_unique();
-    let args = args::CreateOrderS2lLst {
+    let args = args::CreateOrderStableToLeverLst {
       nonce: 42,
       escrow_amount: 1000,
       trigger_price: 100,
       trigger_expo: -8,
       direction: TriggerDirection::AtOrAbove,
     };
-    let ix = create_order_s2l_lst(owner, order, &args);
+    let ix = create_order_stable_to_lever_lst(owner, order, &args);
     assert_eq!(ix.program_id, trigger_orders::ID);
     // Anchor: 8-byte discriminator + borsh args.
     // 8 + 8(nonce u64) + 8(escrow u64) + 8(trigger_price i64) + 4(expo i32)
@@ -289,15 +303,15 @@ mod tests {
   }
 
   #[test]
-  fn create_order_s2l_exo_returns_well_formed_instruction() {
+  fn create_order_stable_to_lever_exo_returns_well_formed_instruction() {
     let owner = Pubkey::new_unique();
     let order = Pubkey::new_unique();
     let collateral_mint = Pubkey::new_unique();
-    let ix = create_order_s2l_exo(
+    let ix = create_order_stable_to_lever_exo(
       owner,
       order,
       collateral_mint,
-      &create_args_s2l_exo(),
+      &create_args_stable_to_lever_exo(),
     );
     assert_eq!(ix.program_id, trigger_orders::ID);
     assert_eq!(ix.data.len(), 37);
@@ -307,10 +321,14 @@ mod tests {
   }
 
   #[test]
-  fn create_order_l2s_lst_returns_well_formed_instruction() {
+  fn create_order_lever_to_stable_lst_returns_well_formed_instruction() {
     let owner = Pubkey::new_unique();
     let order = Pubkey::new_unique();
-    let ix = create_order_l2s_lst(owner, order, &create_args_l2s_lst());
+    let ix = create_order_lever_to_stable_lst(
+      owner,
+      order,
+      &create_args_lever_to_stable_lst(),
+    );
     assert_eq!(ix.program_id, trigger_orders::ID);
     assert_eq!(ix.data.len(), 37);
     assert_eq!(ix.accounts.len(), 11);
@@ -319,15 +337,15 @@ mod tests {
   }
 
   #[test]
-  fn create_order_l2s_exo_returns_well_formed_instruction() {
+  fn create_order_lever_to_stable_exo_returns_well_formed_instruction() {
     let owner = Pubkey::new_unique();
     let order = Pubkey::new_unique();
     let collateral_mint = Pubkey::new_unique();
-    let ix = create_order_l2s_exo(
+    let ix = create_order_lever_to_stable_exo(
       owner,
       order,
       collateral_mint,
-      &create_args_l2s_exo(),
+      &create_args_lever_to_stable_exo(),
     );
     assert_eq!(ix.program_id, trigger_orders::ID);
     assert_eq!(ix.data.len(), 37);
@@ -337,12 +355,12 @@ mod tests {
   }
 
   #[test]
-  fn execute_order_s2l_lst_returns_well_formed_instruction() {
+  fn execute_order_stable_to_lever_lst_returns_well_formed_instruction() {
     let executor = Pubkey::new_unique();
     let owner = Pubkey::new_unique();
     let order = Pubkey::new_unique();
     let hylo = healthy_hylo_min();
-    let ix = execute_order_s2l_lst(executor, owner, order, &hylo);
+    let ix = execute_order_stable_to_lever_lst(executor, owner, order, &hylo);
     assert_eq!(ix.program_id, trigger_orders::ID);
     assert_eq!(ix.data.len(), 8);
     assert_eq!(ix.accounts.len(), 21);
@@ -350,12 +368,12 @@ mod tests {
   }
 
   #[test]
-  fn execute_order_l2s_lst_returns_well_formed_instruction() {
+  fn execute_order_lever_to_stable_lst_returns_well_formed_instruction() {
     let executor = Pubkey::new_unique();
     let owner = Pubkey::new_unique();
     let order = Pubkey::new_unique();
     let hylo = healthy_hylo_min();
-    let ix = execute_order_l2s_lst(executor, owner, order, &hylo);
+    let ix = execute_order_lever_to_stable_lst(executor, owner, order, &hylo);
     assert_eq!(ix.program_id, trigger_orders::ID);
     assert_eq!(ix.data.len(), 8);
     assert_eq!(ix.accounts.len(), 21);
@@ -363,14 +381,14 @@ mod tests {
   }
 
   #[test]
-  fn execute_order_s2l_exo_returns_well_formed_instruction() {
+  fn execute_order_stable_to_lever_exo_returns_well_formed_instruction() {
     let executor = Pubkey::new_unique();
     let owner = Pubkey::new_unique();
     let order = Pubkey::new_unique();
     let collateral_mint = Pubkey::new_unique();
     let hylo = healthy_hylo_min();
     let exo_pair = healthy_exo_pair_min();
-    let ix = execute_order_s2l_exo(
+    let ix = execute_order_stable_to_lever_exo(
       executor,
       owner,
       order,
@@ -385,14 +403,14 @@ mod tests {
   }
 
   #[test]
-  fn execute_order_l2s_exo_returns_well_formed_instruction() {
+  fn execute_order_lever_to_stable_exo_returns_well_formed_instruction() {
     let executor = Pubkey::new_unique();
     let owner = Pubkey::new_unique();
     let order = Pubkey::new_unique();
     let collateral_mint = Pubkey::new_unique();
     let hylo = healthy_hylo_min();
     let exo_pair = healthy_exo_pair_min();
-    let ix = execute_order_l2s_exo(
+    let ix = execute_order_lever_to_stable_exo(
       executor,
       owner,
       order,
@@ -407,10 +425,14 @@ mod tests {
   }
 
   #[test]
-  fn cancel_order_s2l_returns_well_formed_instruction() {
+  fn cancel_order_stable_to_lever_returns_well_formed_instruction() {
     let owner = Pubkey::new_unique();
     let order = Pubkey::new_unique();
-    let ix = cancel_order_s2l(owner, order, &args::CancelOrderS2l {});
+    let ix = cancel_order_stable_to_lever(
+      owner,
+      order,
+      &args::CancelOrderStableToLever {},
+    );
     assert_eq!(ix.program_id, trigger_orders::ID);
     assert_eq!(ix.data.len(), 8);
     assert_eq!(ix.accounts.len(), 8);
@@ -419,10 +441,14 @@ mod tests {
   }
 
   #[test]
-  fn cancel_order_l2s_lst_returns_well_formed_instruction() {
+  fn cancel_order_lever_to_stable_lst_returns_well_formed_instruction() {
     let owner = Pubkey::new_unique();
     let order = Pubkey::new_unique();
-    let ix = cancel_order_l2s_lst(owner, order, &args::CancelOrderL2sLst {});
+    let ix = cancel_order_lever_to_stable_lst(
+      owner,
+      order,
+      &args::CancelOrderLeverToStableLst {},
+    );
     assert_eq!(ix.program_id, trigger_orders::ID);
     assert_eq!(ix.data.len(), 8);
     assert_eq!(ix.accounts.len(), 8);
@@ -431,15 +457,15 @@ mod tests {
   }
 
   #[test]
-  fn cancel_order_l2s_exo_returns_well_formed_instruction() {
+  fn cancel_order_lever_to_stable_exo_returns_well_formed_instruction() {
     let owner = Pubkey::new_unique();
     let order = Pubkey::new_unique();
     let collateral_mint = Pubkey::new_unique();
-    let ix = cancel_order_l2s_exo(
+    let ix = cancel_order_lever_to_stable_exo(
       owner,
       order,
       collateral_mint,
-      &args::CancelOrderL2sExo {},
+      &args::CancelOrderLeverToStableExo {},
     );
     assert_eq!(ix.program_id, trigger_orders::ID);
     assert_eq!(ix.data.len(), 8);

--- a/hylo-idl/src/lib.rs
+++ b/hylo-idl/src/lib.rs
@@ -123,7 +123,8 @@ mod trigger_orders_smoke_tests {
   // adjust `pub mod trigger_orders { ... }` in lib.rs accordingly.
   #[allow(unused_imports)]
   use crate::trigger_orders::events::{
-    TriggerOrderCancelled, TriggerOrderCreated, TriggerOrderFilled,
+    TriggerOrderCancelledEvent, TriggerOrderCreatedEvent,
+    TriggerOrderFilledEvent,
   };
 
   #[test]

--- a/hylo-idl/src/pda.rs
+++ b/hylo-idl/src/pda.rs
@@ -241,7 +241,7 @@ use crate::trigger_orders::types::{ConvertDirection, PairTarget};
 /// Seed for `TriggerOrder` PDAs — byte-equal to `hylo_trigger_orders::ORDER`.
 pub const TRIGGER_ORDER: &[u8; 5] = b"order";
 
-/// PDA for an LST trigger order (s2l or l2s).
+/// PDA for an LST trigger order (stable-to-lever or lever-to-stable).
 #[must_use]
 pub fn trigger_order_lst(
   owner: Pubkey,
@@ -260,7 +260,7 @@ pub fn trigger_order_lst(
   )
 }
 
-/// PDA for an EXO trigger order (s2l or l2s).
+/// PDA for an EXO trigger order (stable-to-lever or lever-to-stable).
 #[must_use]
 pub fn trigger_order_exo(
   owner: Pubkey,
@@ -307,7 +307,7 @@ mod trigger_orders_pda_tests {
       &[
         TRIGGER_ORDER,
         owner.as_ref(),
-        &[ConvertDirection::S2L_TAG],
+        &[ConvertDirection::STABLE_TO_LEVER_TAG],
         &[PairTarget::LST_TAG],
         &42u64.to_le_bytes(),
       ],
@@ -326,7 +326,7 @@ mod trigger_orders_pda_tests {
       &[
         TRIGGER_ORDER,
         owner.as_ref(),
-        &[ConvertDirection::L2S_TAG],
+        &[ConvertDirection::LEVER_TO_STABLE_TAG],
         &[PairTarget::EXO_TAG],
         mint.as_ref(),
         &7u64.to_le_bytes(),
@@ -347,10 +347,16 @@ mod trigger_orders_pda_tests {
   }
 
   #[test]
-  fn s2l_and_l2s_pdas_disjoint_at_same_owner_pair_nonce() {
+  fn stable_to_lever_and_lever_to_stable_pdas_disjoint_at_same_owner_pair_nonce(
+  ) {
     let owner = Pubkey::new_unique();
-    let (s2l, _) = trigger_order_lst(owner, ConvertDirection::StableToLever, 1);
-    let (l2s, _) = trigger_order_lst(owner, ConvertDirection::LeverToStable, 1);
-    assert_ne!(s2l, l2s, "direction-tag separation broken");
+    let (stable_to_lever, _) =
+      trigger_order_lst(owner, ConvertDirection::StableToLever, 1);
+    let (lever_to_stable, _) =
+      trigger_order_lst(owner, ConvertDirection::LeverToStable, 1);
+    assert_ne!(
+      stable_to_lever, lever_to_stable,
+      "direction-tag separation broken"
+    );
   }
 }

--- a/hylo-idl/src/trigger_orders_ext.rs
+++ b/hylo-idl/src/trigger_orders_ext.rs
@@ -58,17 +58,17 @@ impl TriggerOrder {
 
 impl ConvertDirection {
   /// PDA seed-slice tag for `StableToLever` orders. Must match
-  /// `hylo_trigger_orders::state::ConvertDirection::S2L_TAG`.
-  pub const S2L_TAG: u8 = 0;
+  /// `hylo_trigger_orders::state::ConvertDirection::STABLE_TO_LEVER_TAG`.
+  pub const STABLE_TO_LEVER_TAG: u8 = 0;
   /// PDA seed-slice tag for `LeverToStable` orders. Must match
-  /// `hylo_trigger_orders::state::ConvertDirection::L2S_TAG`.
-  pub const L2S_TAG: u8 = 1;
+  /// `hylo_trigger_orders::state::ConvertDirection::LEVER_TO_STABLE_TAG`.
+  pub const LEVER_TO_STABLE_TAG: u8 = 1;
 
   #[must_use]
   pub const fn tag_byte(&self) -> u8 {
     match self {
-      Self::StableToLever => Self::S2L_TAG,
-      Self::LeverToStable => Self::L2S_TAG,
+      Self::StableToLever => Self::STABLE_TO_LEVER_TAG,
+      Self::LeverToStable => Self::LEVER_TO_STABLE_TAG,
     }
   }
 }
@@ -212,7 +212,7 @@ mod can_execute_tests {
 
   // `TriggerOrder` intentionally does NOT derive `Default`, so this fixture
   // lists every field explicitly — adding a field forces it to be updated.
-  fn lst_order_s2l_at_above_trigger() -> TriggerOrder {
+  fn lst_order_stable_to_lever_at_above_trigger() -> TriggerOrder {
     TriggerOrder {
       owner: Pubkey::default(),
       pair_target: PairTarget::Lst,
@@ -224,14 +224,15 @@ mod can_execute_tests {
       direction: TriggerDirection::AtOrAbove,
       created_at: 0,
       bump: 0,
+      _reserved: [0u8; 64],
     }
   }
 
   // An `Exo`-variant order at-or-above its trigger. Clones the LST fixture
   // and swaps the pair target so the EXO code paths in `can_execute` are
   // exercised. (`TriggerOrder` is `Copy`, so the clone is a plain reassign.)
-  fn exo_order_s2l_at_above_trigger() -> TriggerOrder {
-    let mut order = lst_order_s2l_at_above_trigger();
+  fn exo_order_stable_to_lever_at_above_trigger() -> TriggerOrder {
+    let mut order = lst_order_stable_to_lever_at_above_trigger();
     order.pair_target = PairTarget::Exo {
       collateral_mint: Pubkey::new_unique(),
     };
@@ -300,14 +301,14 @@ mod can_execute_tests {
 
   #[test]
   fn met_and_healthy_returns_ok() {
-    let order = lst_order_s2l_at_above_trigger();
+    let order = lst_order_stable_to_lever_at_above_trigger();
     let hylo = healthy_hylo(978);
     assert!(order.can_execute(&hylo, None, 150, -8, 978).is_ok());
   }
 
   #[test]
   fn trigger_not_met_returns_trigger_not_met() {
-    let order = lst_order_s2l_at_above_trigger();
+    let order = lst_order_stable_to_lever_at_above_trigger();
     let hylo = healthy_hylo(978);
     assert_eq!(
       order.can_execute(&hylo, None, 50, -8, 978),
@@ -317,7 +318,7 @@ mod can_execute_tests {
 
   #[test]
   fn expo_mismatch_returns_expo_mismatch() {
-    let order = lst_order_s2l_at_above_trigger();
+    let order = lst_order_stable_to_lever_at_above_trigger();
     let hylo = healthy_hylo(978);
     assert_eq!(
       order.can_execute(&hylo, None, 150, -6, 978),
@@ -327,7 +328,7 @@ mod can_execute_tests {
 
   #[test]
   fn protocol_paused_returns_protocol_paused() {
-    let order = lst_order_s2l_at_above_trigger();
+    let order = lst_order_stable_to_lever_at_above_trigger();
     let mut hylo = healthy_hylo(978);
     hylo.protocol_paused = true;
     assert_eq!(
@@ -338,7 +339,7 @@ mod can_execute_tests {
 
   #[test]
   fn lst_pair_paused_returns_lst_pair_paused() {
-    let order = lst_order_s2l_at_above_trigger();
+    let order = lst_order_stable_to_lever_at_above_trigger();
     let mut hylo = healthy_hylo(978);
     hylo.lst_pair_paused = true;
     assert_eq!(
@@ -349,7 +350,7 @@ mod can_execute_tests {
 
   #[test]
   fn drawdown_outstanding_returns_drawdown_not_repaid() {
-    let order = lst_order_s2l_at_above_trigger();
+    let order = lst_order_stable_to_lever_at_above_trigger();
     let mut hylo = healthy_hylo(978);
     hylo.pool_drawdown.ledger.supply.bits = 1;
     assert_eq!(
@@ -360,7 +361,7 @@ mod can_execute_tests {
 
   #[test]
   fn yield_harvest_stale_returns_stale() {
-    let order = lst_order_s2l_at_above_trigger();
+    let order = lst_order_stable_to_lever_at_above_trigger();
     let hylo = healthy_hylo(977); // one epoch behind
     assert_eq!(
       order.can_execute(&hylo, None, 150, -8, 978),
@@ -370,7 +371,7 @@ mod can_execute_tests {
 
   #[test]
   fn pair_state_shape_mismatch() {
-    let order = lst_order_s2l_at_above_trigger();
+    let order = lst_order_stable_to_lever_at_above_trigger();
     let hylo = healthy_hylo(978);
     let mut exo_order = order;
     exo_order.pair_target = PairTarget::Exo {
@@ -384,7 +385,7 @@ mod can_execute_tests {
 
   #[test]
   fn exo_met_and_healthy_returns_ok() {
-    let order = exo_order_s2l_at_above_trigger();
+    let order = exo_order_stable_to_lever_at_above_trigger();
     let hylo = healthy_hylo(978);
     let exo_pair = healthy_exo_pair(978);
     assert!(order
@@ -394,7 +395,7 @@ mod can_execute_tests {
 
   #[test]
   fn exo_pair_paused_returns_exo_pair_paused() {
-    let order = exo_order_s2l_at_above_trigger();
+    let order = exo_order_stable_to_lever_at_above_trigger();
     let hylo = healthy_hylo(978);
     let mut exo_pair = healthy_exo_pair(978);
     exo_pair.paused = true;
@@ -406,7 +407,7 @@ mod can_execute_tests {
 
   #[test]
   fn exo_drawdown_outstanding_returns_drawdown_not_repaid() {
-    let order = exo_order_s2l_at_above_trigger();
+    let order = exo_order_stable_to_lever_at_above_trigger();
     let hylo = healthy_hylo(978);
     let mut exo_pair = healthy_exo_pair(978);
     exo_pair.pool_drawdown.ledger.supply.bits = 1;
@@ -418,7 +419,7 @@ mod can_execute_tests {
 
   #[test]
   fn exo_borrow_rate_harvest_stale_returns_stale() {
-    let order = exo_order_s2l_at_above_trigger();
+    let order = exo_order_stable_to_lever_at_above_trigger();
     let hylo = healthy_hylo(978);
     let exo_pair = healthy_exo_pair(977); // one epoch behind
     assert_eq!(
@@ -429,7 +430,7 @@ mod can_execute_tests {
 
   #[test]
   fn lst_order_with_some_exo_pair_returns_pair_state_mismatch() {
-    let order = lst_order_s2l_at_above_trigger();
+    let order = lst_order_stable_to_lever_at_above_trigger();
     let hylo = healthy_hylo(978);
     let exo_pair = healthy_exo_pair(978);
     assert_eq!(
@@ -445,8 +446,8 @@ mod tag_tests {
 
   #[test]
   fn convert_direction_tags() {
-    assert_eq!(ConvertDirection::S2L_TAG, 0);
-    assert_eq!(ConvertDirection::L2S_TAG, 1);
+    assert_eq!(ConvertDirection::STABLE_TO_LEVER_TAG, 0);
+    assert_eq!(ConvertDirection::LEVER_TO_STABLE_TAG, 1);
     assert_eq!(ConvertDirection::StableToLever.tag_byte(), 0);
     assert_eq!(ConvertDirection::LeverToStable.tag_byte(), 1);
   }
@@ -501,6 +502,7 @@ mod evaluate_trigger_tests {
       direction,
       created_at: 0,
       bump: 0,
+      _reserved: [0u8; 64],
     }
   }
 

--- a/hylo-idl/src/trigger_orders_ext.rs
+++ b/hylo-idl/src/trigger_orders_ext.rs
@@ -224,7 +224,6 @@ mod can_execute_tests {
       direction: TriggerDirection::AtOrAbove,
       created_at: 0,
       bump: 0,
-      _reserved: [0u8; 64],
     }
   }
 
@@ -502,7 +501,6 @@ mod evaluate_trigger_tests {
       direction,
       created_at: 0,
       bump: 0,
-      _reserved: [0u8; 64],
     }
   }
 


### PR DESCRIPTION
Propagate rename through declare_program! + IDLs (mainnet+shadow): client methods, Event re-exports, builders, PDA helpers; TipArithmetic, read-only hylo, _reserved removed. Green both configs.