### PR TITLE
feat(trigger-orders): TriggerOrdersClient + IDL bindings

### DIFF
--- a/hylo-clients/src/lib.rs
+++ b/hylo-clients/src/lib.rs
@@ -40,4 +40,5 @@ pub mod program_client;
 pub mod router_client;
 pub mod squads;
 pub mod transaction;
+pub mod trigger_orders_client;
 pub mod util;

--- a/hylo-clients/src/lib.rs
+++ b/hylo-clients/src/lib.rs
@@ -31,6 +31,8 @@
 //!   program
 //! - [`earn_pool_client::EarnPoolClient`] — Admin operations for the earn pool
 //!   program
+//! - [`trigger_orders_client::TriggerOrdersClient`] — Permissionless
+//!   trigger-order placement, cancellation, and execution
 
 pub mod earn_pool_client;
 pub mod exchange_client;

--- a/hylo-clients/src/prelude.rs
+++ b/hylo-clients/src/prelude.rs
@@ -18,5 +18,6 @@ pub use crate::transaction::{BuildTransactionData, TransactionSyntax};
 pub use crate::trigger_orders_client::{
   ConvertDirection, ExecutabilityBlocker, PairTarget, TriggerDirection,
   TriggerOrder, TriggerOrderCancelled, TriggerOrderCreated, TriggerOrderFilled,
-  TriggerOrdersClient, TriggerOutcome, EXECUTOR_TIP_LAMPORTS,
+  TriggerOrdersClient, TriggerOutcome, CONSERVATIVE_EXECUTE_CU,
+  EXECUTOR_TIP_LAMPORTS,
 };

--- a/hylo-clients/src/prelude.rs
+++ b/hylo-clients/src/prelude.rs
@@ -15,3 +15,8 @@ pub use crate::router_client::{
   InstructionBuilder, InstructionBuilderExt, RouterArgs, RouterClient,
 };
 pub use crate::transaction::{BuildTransactionData, TransactionSyntax};
+pub use crate::trigger_orders_client::{
+  ConvertDirection, ExecutabilityBlocker, PairTarget, TriggerDirection,
+  TriggerOrder, TriggerOrderCancelled, TriggerOrderCreated, TriggerOrderFilled,
+  TriggerOrdersClient, TriggerOutcome, EXECUTOR_TIP_LAMPORTS,
+};

--- a/hylo-clients/src/prelude.rs
+++ b/hylo-clients/src/prelude.rs
@@ -17,7 +17,7 @@ pub use crate::router_client::{
 pub use crate::transaction::{BuildTransactionData, TransactionSyntax};
 pub use crate::trigger_orders_client::{
   ConvertDirection, ExecutabilityBlocker, PairTarget, TriggerDirection,
-  TriggerOrder, TriggerOrderCancelled, TriggerOrderCreated, TriggerOrderFilled,
-  TriggerOrdersClient, TriggerOutcome, CONSERVATIVE_EXECUTE_CU,
-  EXECUTOR_TIP_LAMPORTS,
+  TriggerOrder, TriggerOrderCancelledEvent, TriggerOrderCreatedEvent,
+  TriggerOrderFilledEvent, TriggerOrdersClient, TriggerOutcome,
+  CONSERVATIVE_EXECUTE_CU, EXECUTOR_TIP_LAMPORTS,
 };

--- a/hylo-clients/src/program_client.rs
+++ b/hylo-clients/src/program_client.rs
@@ -44,6 +44,18 @@ impl VersionedTransactionData {
       lookup_tables,
     }
   }
+
+  /// Prepend a `ComputeBudget::SetComputeUnitLimit` instruction. Use for
+  /// transactions whose CU consumption exceeds the 200k default
+  /// (e.g., trigger-orders execute, 400k recommended).
+  #[must_use]
+  pub fn with_compute_unit_limit(mut self, limit: u32) -> Self {
+    use anchor_client::solana_sdk::compute_budget::ComputeBudgetInstruction;
+    self
+      .instructions
+      .insert(0, ComputeBudgetInstruction::set_compute_unit_limit(limit));
+    self
+  }
 }
 
 /// Abstracts the construction of client structs with `anchor_client::Program`.
@@ -283,5 +295,40 @@ pub trait ProgramClient: Sized {
     let event = parse_event(&result)?;
     let compute_units = result.value.units_consumed;
     Ok((event, compute_units))
+  }
+}
+
+#[cfg(test)]
+mod compute_unit_limit_tests {
+  use anchor_client::solana_sdk::instruction::Instruction;
+  use anchor_client::solana_sdk::pubkey::Pubkey;
+
+  use super::*;
+
+  fn nop() -> Instruction {
+    Instruction {
+      program_id: Pubkey::new_unique(),
+      accounts: vec![],
+      data: vec![],
+    }
+  }
+
+  #[test]
+  fn with_compute_unit_limit_prepends_compute_budget_ix() {
+    let tx =
+      VersionedTransactionData::one(nop()).with_compute_unit_limit(400_000);
+    assert_eq!(tx.instructions.len(), 2);
+    // First instruction is from the compute-budget program.
+    assert_eq!(
+      tx.instructions[0].program_id,
+      anchor_client::solana_sdk::compute_budget::ID,
+    );
+  }
+
+  #[test]
+  fn with_compute_unit_limit_preserves_lookup_tables() {
+    let tx = VersionedTransactionData::new(vec![nop()], vec![])
+      .with_compute_unit_limit(400_000);
+    assert_eq!(tx.lookup_tables.len(), 0);
   }
 }

--- a/hylo-clients/src/program_client.rs
+++ b/hylo-clients/src/program_client.rs
@@ -16,7 +16,8 @@ use itertools::Itertools;
 
 use crate::util::{
   build_lst_registry, build_v0_transaction, deserialize_lookup_table,
-  parse_event, simulation_config, LST_REGISTRY_LOOKUP_TABLE,
+  parse_event, parse_event_filtered, simulation_config,
+  LST_REGISTRY_LOOKUP_TABLE,
 };
 
 /// Components from which a [`VersionedTransaction`] can be built.
@@ -295,6 +296,28 @@ pub trait ProgramClient: Sized {
     let event = parse_event(&result)?;
     let compute_units = result.value.units_consumed;
     Ok((event, compute_units))
+  }
+
+  /// Run one simulation and extract a specific event by discriminator.
+  /// Use when a tx emits multiple events and you need a specific type —
+  /// `simulate_transaction_event<E>` only returns the first
+  /// `PartiallyDecoded` ix regardless of type, which can't extract multiple
+  /// event types from the same result.
+  ///
+  /// # Errors
+  /// * Transaction simulation fails
+  /// * No event matching `E::DISCRIMINATOR` present, or deserialization fails
+  async fn simulate_transaction_event_filtered<
+    E: AnchorDeserialize + Discriminator,
+  >(
+    &self,
+    tx: &VersionedTransaction,
+  ) -> Result<E> {
+    let rpc = self.program().rpc();
+    let result = rpc
+      .simulate_transaction_with_config(tx, simulation_config())
+      .await?;
+    parse_event_filtered(&result)
   }
 }
 

--- a/hylo-clients/src/trigger_orders_client.rs
+++ b/hylo-clients/src/trigger_orders_client.rs
@@ -1,0 +1,61 @@
+//! Off-chain client for `hylo-trigger-orders`. Permissionless — no admin
+//! authority, no Squads wrapping.
+
+use std::sync::Arc;
+
+use anchor_client::solana_sdk::pubkey::Pubkey;
+use anchor_client::solana_sdk::signature::Keypair;
+use anchor_client::Program;
+use hylo_idl::trigger_orders;
+
+use crate::program_client::ProgramClient;
+
+/// Permissionless client for the Hylo trigger-orders program. Manages
+/// trigger-order placement, cancellation, and execution. Unlike the admin
+/// clients, there is no authority or Squads wrapping — any keypair can drive
+/// these operations.
+pub struct TriggerOrdersClient {
+  program: Program<Arc<Keypair>>,
+  keypair: Arc<Keypair>,
+}
+
+impl ProgramClient for TriggerOrdersClient {
+  const PROGRAM_ID: Pubkey = trigger_orders::ID;
+
+  fn build_client(
+    program: Program<Arc<Keypair>>,
+    keypair: Arc<Keypair>,
+  ) -> TriggerOrdersClient {
+    TriggerOrdersClient { program, keypair }
+  }
+
+  fn program(&self) -> &Program<Arc<Keypair>> {
+    &self.program
+  }
+
+  fn keypair(&self) -> Arc<Keypair> {
+    self.keypair.clone()
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use anchor_client::solana_sdk::commitment_config::CommitmentConfig;
+  use anchor_client::Cluster;
+
+  use super::*;
+
+  #[test]
+  fn client_id_matches_trigger_orders_program_id() {
+    let c = TriggerOrdersClient::new_random_keypair(
+      Cluster::Localnet,
+      CommitmentConfig::confirmed(),
+    )
+    .expect("build");
+    assert_eq!(
+      <TriggerOrdersClient as ProgramClient>::PROGRAM_ID,
+      trigger_orders::ID
+    );
+    let _ = c.keypair(); // exercise the trait method
+  }
+}

--- a/hylo-clients/src/trigger_orders_client.rs
+++ b/hylo-clients/src/trigger_orders_client.rs
@@ -10,7 +10,9 @@ use anchor_client::Program;
 use anyhow::Result;
 use hylo_idl::trigger_orders::client::args;
 use hylo_idl::trigger_orders::instruction_builders;
-use hylo_idl::trigger_orders::types::{ConvertDirection, TriggerDirection};
+use hylo_idl::trigger_orders::types::{
+  ConvertDirection, PairTarget, TriggerDirection,
+};
 use hylo_idl::{pda, trigger_orders};
 
 use crate::program_client::{ProgramClient, VersionedTransactionData};
@@ -180,6 +182,85 @@ impl TriggerOrdersClient {
     );
     Ok(VersionedTransactionData::one(ix))
   }
+
+  /// Cancel an s2l trigger order. Refunds HYUSD escrow + executor tip to
+  /// the owner via Anchor's `close = owner`. Handles both LST and EXO s2l
+  /// (the s2l escrow is always HYUSD), selected by `pair_target`.
+  ///
+  /// # Errors
+  /// * Failed to build transaction instructions
+  #[allow(clippy::unused_async)] // async for surface uniformity; see s2l_lst.
+  pub async fn cancel_order_s2l(
+    &self,
+    nonce: u64,
+    pair_target: PairTarget,
+  ) -> Result<VersionedTransactionData> {
+    let owner = self.keypair.pubkey();
+    let (order, _) = match pair_target {
+      PairTarget::Lst => {
+        pda::trigger_order_lst(owner, ConvertDirection::StableToLever, nonce)
+      }
+      PairTarget::Exo { collateral_mint } => pda::trigger_order_exo(
+        owner,
+        ConvertDirection::StableToLever,
+        collateral_mint,
+        nonce,
+      ),
+    };
+    let ix = instruction_builders::cancel_order_s2l(
+      owner,
+      order,
+      &args::CancelOrderS2l {},
+    );
+    Ok(VersionedTransactionData::one(ix))
+  }
+
+  /// Cancel an l2s LST order. Refunds xSOL escrow + tip via `close = owner`.
+  ///
+  /// # Errors
+  /// * Failed to build transaction instructions
+  #[allow(clippy::unused_async)] // async for surface uniformity; see s2l_lst.
+  pub async fn cancel_order_l2s_lst(
+    &self,
+    nonce: u64,
+  ) -> Result<VersionedTransactionData> {
+    let owner = self.keypair.pubkey();
+    let (order, _) =
+      pda::trigger_order_lst(owner, ConvertDirection::LeverToStable, nonce);
+    let ix = instruction_builders::cancel_order_l2s_lst(
+      owner,
+      order,
+      &args::CancelOrderL2sLst {},
+    );
+    Ok(VersionedTransactionData::one(ix))
+  }
+
+  /// Cancel an l2s EXO order. Refunds the per-collateral levercoin escrow +
+  /// tip.
+  ///
+  /// # Errors
+  /// * Failed to build transaction instructions
+  #[allow(clippy::unused_async)] // async for surface uniformity; see s2l_lst.
+  pub async fn cancel_order_l2s_exo(
+    &self,
+    collateral_mint: Pubkey,
+    nonce: u64,
+  ) -> Result<VersionedTransactionData> {
+    let owner = self.keypair.pubkey();
+    let (order, _) = pda::trigger_order_exo(
+      owner,
+      ConvertDirection::LeverToStable,
+      collateral_mint,
+      nonce,
+    );
+    let ix = instruction_builders::cancel_order_l2s_exo(
+      owner,
+      order,
+      collateral_mint,
+      &args::CancelOrderL2sExo {},
+    );
+    Ok(VersionedTransactionData::one(ix))
+  }
 }
 
 #[cfg(test)]
@@ -187,7 +268,9 @@ mod tests {
   use anchor_client::solana_sdk::commitment_config::CommitmentConfig;
   use anchor_client::Cluster;
   use hylo_idl::pda;
-  use hylo_idl::trigger_orders::types::{ConvertDirection, TriggerDirection};
+  use hylo_idl::trigger_orders::types::{
+    ConvertDirection, PairTarget, TriggerDirection,
+  };
 
   use super::*;
 
@@ -313,6 +396,102 @@ mod tests {
       ConvertDirection::LeverToStable,
       collateral_mint,
       9,
+    );
+    assert_eq!(tx.instructions[0].accounts[1].pubkey, expected_pda);
+  }
+
+  #[tokio::test]
+  async fn cancel_order_s2l_lst_derives_lst_pda() {
+    let c = TriggerOrdersClient::new_random_keypair(
+      Cluster::Localnet,
+      CommitmentConfig::confirmed(),
+    )
+    .unwrap();
+    let owner = c.keypair().pubkey();
+
+    let tx = c
+      .cancel_order_s2l(11, PairTarget::Lst)
+      .await
+      .expect("build tx");
+
+    assert_eq!(tx.instructions.len(), 1);
+    assert_eq!(tx.instructions[0].program_id, trigger_orders::ID);
+
+    let (expected_pda, _) =
+      pda::trigger_order_lst(owner, ConvertDirection::StableToLever, 11);
+    // The `order` account is at position 1 (owner, then order).
+    assert_eq!(tx.instructions[0].accounts[1].pubkey, expected_pda);
+  }
+
+  #[tokio::test]
+  async fn cancel_order_s2l_exo_derives_exo_pda() {
+    let c = TriggerOrdersClient::new_random_keypair(
+      Cluster::Localnet,
+      CommitmentConfig::confirmed(),
+    )
+    .unwrap();
+    let owner = c.keypair().pubkey();
+    let collateral_mint = Pubkey::new_unique();
+
+    let tx = c
+      .cancel_order_s2l(12, PairTarget::Exo { collateral_mint })
+      .await
+      .expect("build tx");
+
+    assert_eq!(tx.instructions.len(), 1);
+    assert_eq!(tx.instructions[0].program_id, trigger_orders::ID);
+
+    let (expected_pda, _) = pda::trigger_order_exo(
+      owner,
+      ConvertDirection::StableToLever,
+      collateral_mint,
+      12,
+    );
+    assert_eq!(tx.instructions[0].accounts[1].pubkey, expected_pda);
+  }
+
+  #[tokio::test]
+  async fn cancel_order_l2s_lst_derives_pda() {
+    let c = TriggerOrdersClient::new_random_keypair(
+      Cluster::Localnet,
+      CommitmentConfig::confirmed(),
+    )
+    .unwrap();
+    let owner = c.keypair().pubkey();
+
+    let tx = c.cancel_order_l2s_lst(13).await.expect("build tx");
+
+    assert_eq!(tx.instructions.len(), 1);
+    assert_eq!(tx.instructions[0].program_id, trigger_orders::ID);
+
+    let (expected_pda, _) =
+      pda::trigger_order_lst(owner, ConvertDirection::LeverToStable, 13);
+    assert_eq!(tx.instructions[0].accounts[1].pubkey, expected_pda);
+  }
+
+  #[tokio::test]
+  async fn cancel_order_l2s_exo_derives_pda() {
+    let c = TriggerOrdersClient::new_random_keypair(
+      Cluster::Localnet,
+      CommitmentConfig::confirmed(),
+    )
+    .unwrap();
+    let owner = c.keypair().pubkey();
+    let collateral_mint = Pubkey::new_unique();
+
+    let tx = c
+      .cancel_order_l2s_exo(collateral_mint, 14)
+      .await
+      .expect("build tx");
+
+    assert_eq!(tx.instructions.len(), 1);
+    assert_eq!(tx.instructions[0].program_id, trigger_orders::ID);
+
+    let (expected_pda, _) = pda::trigger_order_exo(
+      owner,
+      ConvertDirection::LeverToStable,
+      collateral_mint,
+      14,
     );
     assert_eq!(tx.instructions[0].accounts[1].pubkey, expected_pda);
   }

--- a/hylo-clients/src/trigger_orders_client.rs
+++ b/hylo-clients/src/trigger_orders_client.rs
@@ -5,10 +5,15 @@ use std::sync::Arc;
 
 use anchor_client::solana_sdk::pubkey::Pubkey;
 use anchor_client::solana_sdk::signature::Keypair;
+use anchor_client::solana_sdk::signer::Signer;
 use anchor_client::Program;
-use hylo_idl::trigger_orders;
+use anyhow::Result;
+use hylo_idl::trigger_orders::client::args;
+use hylo_idl::trigger_orders::instruction_builders;
+use hylo_idl::trigger_orders::types::{ConvertDirection, TriggerDirection};
+use hylo_idl::{pda, trigger_orders};
 
-use crate::program_client::ProgramClient;
+use crate::program_client::{ProgramClient, VersionedTransactionData};
 
 /// Permissionless client for the Hylo trigger-orders program. Manages
 /// trigger-order placement, cancellation, and execution. Unlike the admin
@@ -38,10 +43,151 @@ impl ProgramClient for TriggerOrdersClient {
   }
 }
 
+impl TriggerOrdersClient {
+  /// Create a stable→lever LST trigger order. Escrows HYUSD from the
+  /// signer's ATA plus an `EXECUTOR_TIP_LAMPORTS` lamport tip.
+  ///
+  /// # Errors
+  /// * Failed to build transaction instructions
+  // Builds no RPC round-trip today, but keeps an `async` signature for a
+  // uniform `TriggerOrdersClient` surface (matching cancel/execute, some of
+  // which do await) and so future escrow/balance lookups can be added without
+  // a breaking API change.
+  #[allow(clippy::unused_async)]
+  pub async fn create_order_s2l_lst(
+    &self,
+    nonce: u64,
+    escrow_amount: u64,
+    trigger_price: i64,
+    trigger_expo: i32,
+    direction: TriggerDirection,
+  ) -> Result<VersionedTransactionData> {
+    let owner = self.keypair.pubkey();
+    let (order, _) =
+      pda::trigger_order_lst(owner, ConvertDirection::StableToLever, nonce);
+    let ix = instruction_builders::create_order_s2l_lst(
+      owner,
+      order,
+      &args::CreateOrderS2lLst {
+        nonce,
+        escrow_amount,
+        trigger_price,
+        trigger_expo,
+        direction,
+      },
+    );
+    Ok(VersionedTransactionData::one(ix))
+  }
+
+  /// As `create_order_s2l_lst`, but for an EXO pair.
+  ///
+  /// # Errors
+  /// * Failed to build transaction instructions
+  #[allow(clippy::unused_async)] // async for surface uniformity; see s2l_lst.
+  pub async fn create_order_s2l_exo(
+    &self,
+    collateral_mint: Pubkey,
+    nonce: u64,
+    escrow_amount: u64,
+    trigger_price: i64,
+    trigger_expo: i32,
+    direction: TriggerDirection,
+  ) -> Result<VersionedTransactionData> {
+    let owner = self.keypair.pubkey();
+    let (order, _) = pda::trigger_order_exo(
+      owner,
+      ConvertDirection::StableToLever,
+      collateral_mint,
+      nonce,
+    );
+    let ix = instruction_builders::create_order_s2l_exo(
+      owner,
+      order,
+      collateral_mint,
+      &args::CreateOrderS2lExo {
+        nonce,
+        escrow_amount,
+        trigger_price,
+        trigger_expo,
+        direction,
+      },
+    );
+    Ok(VersionedTransactionData::one(ix))
+  }
+
+  /// Lever→Stable LST. Escrows xSOL.
+  ///
+  /// # Errors
+  /// * Failed to build transaction instructions
+  #[allow(clippy::unused_async)] // async for surface uniformity; see s2l_lst.
+  pub async fn create_order_l2s_lst(
+    &self,
+    nonce: u64,
+    escrow_amount: u64,
+    trigger_price: i64,
+    trigger_expo: i32,
+    direction: TriggerDirection,
+  ) -> Result<VersionedTransactionData> {
+    let owner = self.keypair.pubkey();
+    let (order, _) =
+      pda::trigger_order_lst(owner, ConvertDirection::LeverToStable, nonce);
+    let ix = instruction_builders::create_order_l2s_lst(
+      owner,
+      order,
+      &args::CreateOrderL2sLst {
+        nonce,
+        escrow_amount,
+        trigger_price,
+        trigger_expo,
+        direction,
+      },
+    );
+    Ok(VersionedTransactionData::one(ix))
+  }
+
+  /// Lever→Stable EXO. Escrows the per-collateral levercoin.
+  ///
+  /// # Errors
+  /// * Failed to build transaction instructions
+  #[allow(clippy::unused_async)] // async for surface uniformity; see s2l_lst.
+  pub async fn create_order_l2s_exo(
+    &self,
+    collateral_mint: Pubkey,
+    nonce: u64,
+    escrow_amount: u64,
+    trigger_price: i64,
+    trigger_expo: i32,
+    direction: TriggerDirection,
+  ) -> Result<VersionedTransactionData> {
+    let owner = self.keypair.pubkey();
+    let (order, _) = pda::trigger_order_exo(
+      owner,
+      ConvertDirection::LeverToStable,
+      collateral_mint,
+      nonce,
+    );
+    let ix = instruction_builders::create_order_l2s_exo(
+      owner,
+      order,
+      collateral_mint,
+      &args::CreateOrderL2sExo {
+        nonce,
+        escrow_amount,
+        trigger_price,
+        trigger_expo,
+        direction,
+      },
+    );
+    Ok(VersionedTransactionData::one(ix))
+  }
+}
+
 #[cfg(test)]
 mod tests {
   use anchor_client::solana_sdk::commitment_config::CommitmentConfig;
   use anchor_client::Cluster;
+  use hylo_idl::pda;
+  use hylo_idl::trigger_orders::types::{ConvertDirection, TriggerDirection};
 
   use super::*;
 
@@ -57,5 +203,117 @@ mod tests {
       trigger_orders::ID
     );
     let _ = c.keypair(); // exercise the trait method
+  }
+
+  #[tokio::test]
+  async fn create_order_s2l_lst_routes_to_correct_pda() {
+    let c = TriggerOrdersClient::new_random_keypair(
+      Cluster::Localnet,
+      CommitmentConfig::confirmed(),
+    )
+    .unwrap();
+    let owner = c.keypair().pubkey();
+
+    let tx = c
+      .create_order_s2l_lst(7, 1000, 100, -8, TriggerDirection::AtOrAbove)
+      .await
+      .expect("build tx");
+
+    assert_eq!(tx.instructions.len(), 1);
+    assert_eq!(tx.instructions[0].program_id, trigger_orders::ID);
+
+    let (expected_pda, _) =
+      pda::trigger_order_lst(owner, ConvertDirection::StableToLever, 7);
+    // The `order` account is at position 1 (owner, then order).
+    assert_eq!(tx.instructions[0].accounts[1].pubkey, expected_pda);
+  }
+
+  #[tokio::test]
+  async fn create_order_s2l_exo_derives_with_collateral_mint() {
+    let c = TriggerOrdersClient::new_random_keypair(
+      Cluster::Localnet,
+      CommitmentConfig::confirmed(),
+    )
+    .unwrap();
+    let owner = c.keypair().pubkey();
+    let collateral_mint = Pubkey::new_unique();
+
+    let tx = c
+      .create_order_s2l_exo(
+        collateral_mint,
+        3,
+        500,
+        100,
+        -8,
+        TriggerDirection::AtOrAbove,
+      )
+      .await
+      .expect("build tx");
+
+    assert_eq!(tx.instructions.len(), 1);
+    assert_eq!(tx.instructions[0].program_id, trigger_orders::ID);
+
+    let (expected_pda, _) = pda::trigger_order_exo(
+      owner,
+      ConvertDirection::StableToLever,
+      collateral_mint,
+      3,
+    );
+    assert_eq!(tx.instructions[0].accounts[1].pubkey, expected_pda);
+  }
+
+  #[tokio::test]
+  async fn create_order_l2s_lst_routes_to_correct_pda() {
+    let c = TriggerOrdersClient::new_random_keypair(
+      Cluster::Localnet,
+      CommitmentConfig::confirmed(),
+    )
+    .unwrap();
+    let owner = c.keypair().pubkey();
+
+    let tx = c
+      .create_order_l2s_lst(11, 750, 25, -8, TriggerDirection::AtOrBelow)
+      .await
+      .expect("build tx");
+
+    assert_eq!(tx.instructions.len(), 1);
+    assert_eq!(tx.instructions[0].program_id, trigger_orders::ID);
+
+    let (expected_pda, _) =
+      pda::trigger_order_lst(owner, ConvertDirection::LeverToStable, 11);
+    assert_eq!(tx.instructions[0].accounts[1].pubkey, expected_pda);
+  }
+
+  #[tokio::test]
+  async fn create_order_l2s_exo_derives_with_collateral_mint() {
+    let c = TriggerOrdersClient::new_random_keypair(
+      Cluster::Localnet,
+      CommitmentConfig::confirmed(),
+    )
+    .unwrap();
+    let owner = c.keypair().pubkey();
+    let collateral_mint = Pubkey::new_unique();
+    let tx = c
+      .create_order_l2s_exo(
+        collateral_mint,
+        9,
+        2_000,
+        50,
+        -8,
+        TriggerDirection::AtOrBelow,
+      )
+      .await
+      .expect("build tx");
+
+    assert_eq!(tx.instructions.len(), 1);
+    assert_eq!(tx.instructions[0].program_id, trigger_orders::ID);
+
+    let (expected_pda, _) = pda::trigger_order_exo(
+      owner,
+      ConvertDirection::LeverToStable,
+      collateral_mint,
+      9,
+    );
+    assert_eq!(tx.instructions[0].accounts[1].pubkey, expected_pda);
   }
 }

--- a/hylo-clients/src/trigger_orders_client.rs
+++ b/hylo-clients/src/trigger_orders_client.rs
@@ -13,13 +13,17 @@ use hylo_idl::exchange::events::{
   ConvertLeverToStableExoEvent, ConvertLeverToStableLstEvent,
   ConvertStableToLeverExoEvent, ConvertStableToLeverLstEvent,
 };
-use hylo_idl::trigger_orders::accounts::TriggerOrder;
+pub use hylo_idl::trigger_orders::accounts::TriggerOrder;
 use hylo_idl::trigger_orders::client::args;
-use hylo_idl::trigger_orders::events::TriggerOrderFilled;
+pub use hylo_idl::trigger_orders::constants::EXECUTOR_TIP_LAMPORTS;
+pub use hylo_idl::trigger_orders::events::{
+  TriggerOrderCancelled, TriggerOrderCreated, TriggerOrderFilled,
+};
 use hylo_idl::trigger_orders::instruction_builders;
-use hylo_idl::trigger_orders::types::{
+pub use hylo_idl::trigger_orders::types::{
   ConvertDirection, PairTarget, TriggerDirection,
 };
+pub use hylo_idl::trigger_orders::{ExecutabilityBlocker, TriggerOutcome};
 use hylo_idl::{pda, trigger_orders};
 
 use crate::program_client::{ProgramClient, VersionedTransactionData};
@@ -277,7 +281,8 @@ impl TriggerOrdersClient {
   /// state to thread the SOL/USD oracle, builds the CPI, prepends 400k CU.
   ///
   /// # Errors
-  /// RPC error; `Hylo` PDA not found; transaction build failure.
+  /// * RPC error fetching `Hylo`
+  /// * Account deserialization failure
   pub async fn execute_order_s2l_lst(
     &self,
     owner: Pubkey,
@@ -296,10 +301,11 @@ impl TriggerOrdersClient {
     )
   }
 
-  /// As above, lever→stable LST.
+  /// As `execute_order_s2l_lst`, but lever→stable.
   ///
   /// # Errors
-  /// RPC error; `Hylo` PDA not found; transaction build failure.
+  /// * RPC error fetching `Hylo`
+  /// * Account deserialization failure
   pub async fn execute_order_l2s_lst(
     &self,
     owner: Pubkey,
@@ -322,7 +328,8 @@ impl TriggerOrdersClient {
   /// and the `ExoPair` (provides the collateral oracle).
   ///
   /// # Errors
-  /// RPC error; `Hylo`/`ExoPair` PDA not found; transaction build failure.
+  /// * RPC error fetching `Hylo`/`ExoPair`
+  /// * Account deserialization failure
   pub async fn execute_order_s2l_exo(
     &self,
     owner: Pubkey,
@@ -358,7 +365,8 @@ impl TriggerOrdersClient {
   /// Lever→stable EXO. See `execute_order_s2l_exo` re: the `Hylo` fetch.
   ///
   /// # Errors
-  /// RPC error; `Hylo`/`ExoPair` PDA not found; transaction build failure.
+  /// * RPC error fetching `Hylo`/`ExoPair`
+  /// * Account deserialization failure
   pub async fn execute_order_l2s_exo(
     &self,
     owner: Pubkey,

--- a/hylo-clients/src/trigger_orders_client.rs
+++ b/hylo-clients/src/trigger_orders_client.rs
@@ -504,14 +504,16 @@ impl TriggerOrdersClient {
   pub async fn get_order(
     &self,
     owner: Pubkey,
-    direction: ConvertDirection,
+    convert_direction: ConvertDirection,
     pair_target: PairTarget,
     nonce: u64,
   ) -> Result<Option<TriggerOrder>> {
     let (pda_pubkey, _) = match pair_target {
-      PairTarget::Lst => pda::trigger_order_lst(owner, direction, nonce),
+      PairTarget::Lst => {
+        pda::trigger_order_lst(owner, convert_direction, nonce)
+      }
       PairTarget::Exo { collateral_mint } => {
-        pda::trigger_order_exo(owner, direction, collateral_mint, nonce)
+        pda::trigger_order_exo(owner, convert_direction, collateral_mint, nonce)
       }
     };
     match self.program.account::<TriggerOrder>(pda_pubkey).await {

--- a/hylo-clients/src/trigger_orders_client.rs
+++ b/hylo-clients/src/trigger_orders_client.rs
@@ -9,7 +9,12 @@ use anchor_client::solana_sdk::signer::Signer;
 use anchor_client::Program;
 use anyhow::Result;
 use hylo_idl::exchange::accounts::{ExoPair, Hylo};
+use hylo_idl::exchange::events::{
+  ConvertLeverToStableExoEvent, ConvertLeverToStableLstEvent,
+  ConvertStableToLeverExoEvent, ConvertStableToLeverLstEvent,
+};
 use hylo_idl::trigger_orders::client::args;
+use hylo_idl::trigger_orders::events::TriggerOrderFilled;
 use hylo_idl::trigger_orders::instruction_builders;
 use hylo_idl::trigger_orders::types::{
   ConvertDirection, PairTarget, TriggerDirection,
@@ -381,6 +386,105 @@ impl TriggerOrdersClient {
       VersionedTransactionData::one(ix)
         .with_compute_unit_limit(CONSERVATIVE_EXECUTE_CU),
     )
+  }
+
+  // The `simulate_execute_order_*` methods below run TWO simulations (two RPC
+  // round-trips) to extract the outer `TriggerOrderFilled` and the inner Hylo
+  // `Convert*Event` separately. This is acceptable for v1 because `simulate_*`
+  // is low-frequency (keeper pre-flight, not the hot path); it could be
+  // optimized to a single simulation later (parse both events from one result
+  // via `parse_event_filtered`, which is designed to be called repeatedly on
+  // the same result).
+
+  /// Simulate the execute path; return both events the chain emits on
+  /// success: the trigger-orders `TriggerOrderFilled` AND the inner Hylo
+  /// `ConvertStableToLeverLstEvent`.
+  ///
+  /// # Errors
+  /// Simulation failure (CPI revert, account loading, CR-gate blockers);
+  /// either event missing from the simulation result.
+  pub async fn simulate_execute_order_s2l_lst(
+    &self,
+    owner: Pubkey,
+    nonce: u64,
+  ) -> Result<(TriggerOrderFilled, ConvertStableToLeverLstEvent)> {
+    let vtd = self.execute_order_s2l_lst(owner, nonce).await?;
+    let user = self.keypair.pubkey();
+    let vt = self.build_simulation_transaction(&user, &vtd).await?;
+    let outer: TriggerOrderFilled =
+      self.simulate_transaction_event_filtered(&vt).await?;
+    let inner: ConvertStableToLeverLstEvent =
+      self.simulate_transaction_event_filtered(&vt).await?;
+    Ok((outer, inner))
+  }
+
+  /// Simulate the execute path; return the outer `TriggerOrderFilled` and the
+  /// inner Hylo `ConvertLeverToStableLstEvent`.
+  ///
+  /// # Errors
+  /// Simulation failure (CPI revert, account loading, CR-gate blockers);
+  /// either event missing from the simulation result.
+  pub async fn simulate_execute_order_l2s_lst(
+    &self,
+    owner: Pubkey,
+    nonce: u64,
+  ) -> Result<(TriggerOrderFilled, ConvertLeverToStableLstEvent)> {
+    let vtd = self.execute_order_l2s_lst(owner, nonce).await?;
+    let user = self.keypair.pubkey();
+    let vt = self.build_simulation_transaction(&user, &vtd).await?;
+    let outer: TriggerOrderFilled =
+      self.simulate_transaction_event_filtered(&vt).await?;
+    let inner: ConvertLeverToStableLstEvent =
+      self.simulate_transaction_event_filtered(&vt).await?;
+    Ok((outer, inner))
+  }
+
+  /// Simulate the EXO execute path; return the outer `TriggerOrderFilled` and
+  /// the inner Hylo `ConvertStableToLeverExoEvent`.
+  ///
+  /// # Errors
+  /// Simulation failure (CPI revert, account loading, CR-gate blockers);
+  /// either event missing from the simulation result.
+  pub async fn simulate_execute_order_s2l_exo(
+    &self,
+    owner: Pubkey,
+    collateral_mint: Pubkey,
+    nonce: u64,
+  ) -> Result<(TriggerOrderFilled, ConvertStableToLeverExoEvent)> {
+    let vtd = self
+      .execute_order_s2l_exo(owner, collateral_mint, nonce)
+      .await?;
+    let user = self.keypair.pubkey();
+    let vt = self.build_simulation_transaction(&user, &vtd).await?;
+    let outer: TriggerOrderFilled =
+      self.simulate_transaction_event_filtered(&vt).await?;
+    let inner: ConvertStableToLeverExoEvent =
+      self.simulate_transaction_event_filtered(&vt).await?;
+    Ok((outer, inner))
+  }
+
+  /// Simulate the EXO execute path; return the outer `TriggerOrderFilled` and
+  /// the inner Hylo `ConvertLeverToStableExoEvent`.
+  ///
+  /// # Errors
+  /// Simulation failure (CPI revert, account loading, CR-gate blockers);
+  /// either event missing from the simulation result.
+  pub async fn simulate_execute_order_l2s_exo(
+    &self,
+    owner: Pubkey,
+    collateral_mint: Pubkey,
+    nonce: u64,
+  ) -> Result<(TriggerOrderFilled, ConvertLeverToStableExoEvent)> {
+    let vtd = self
+      .execute_order_l2s_exo(owner, collateral_mint, nonce)
+      .await?;
+    let user = self.keypair.pubkey();
+    let vt = self.build_simulation_transaction(&user, &vtd).await?;
+    let outer: TriggerOrderFilled =
+      self.simulate_transaction_event_filtered(&vt).await?;
+    let inner: ConvertLeverToStableExoEvent =
+      self.simulate_transaction_event_filtered(&vt).await?;
+    Ok((outer, inner))
   }
 }
 

--- a/hylo-clients/src/trigger_orders_client.rs
+++ b/hylo-clients/src/trigger_orders_client.rs
@@ -17,7 +17,7 @@ pub use hylo_idl::trigger_orders::accounts::TriggerOrder;
 use hylo_idl::trigger_orders::client::args;
 pub use hylo_idl::trigger_orders::constants::EXECUTOR_TIP_LAMPORTS;
 pub use hylo_idl::trigger_orders::events::{
-  TriggerOrderCancelled, TriggerOrderCreated, TriggerOrderFilled,
+  TriggerOrderCancelledEvent, TriggerOrderCreatedEvent, TriggerOrderFilledEvent,
 };
 use hylo_idl::trigger_orders::instruction_builders;
 pub use hylo_idl::trigger_orders::types::{
@@ -71,7 +71,7 @@ impl TriggerOrdersClient {
   // which do await) and so future escrow/balance lookups can be added without
   // a breaking API change.
   #[allow(clippy::unused_async)]
-  pub async fn create_order_s2l_lst(
+  pub async fn create_order_stable_to_lever_lst(
     &self,
     nonce: u64,
     escrow_amount: u64,
@@ -82,10 +82,10 @@ impl TriggerOrdersClient {
     let owner = self.keypair.pubkey();
     let (order, _) =
       pda::trigger_order_lst(owner, ConvertDirection::StableToLever, nonce);
-    let ix = instruction_builders::create_order_s2l_lst(
+    let ix = instruction_builders::create_order_stable_to_lever_lst(
       owner,
       order,
-      &args::CreateOrderS2lLst {
+      &args::CreateOrderStableToLeverLst {
         nonce,
         escrow_amount,
         trigger_price,
@@ -96,12 +96,12 @@ impl TriggerOrdersClient {
     Ok(VersionedTransactionData::one(ix))
   }
 
-  /// As `create_order_s2l_lst`, but for an EXO pair.
+  /// As `create_order_stable_to_lever_lst`, but for an EXO pair.
   ///
   /// # Errors
   /// * Failed to build transaction instructions
-  #[allow(clippy::unused_async)] // async for surface uniformity; see s2l_lst.
-  pub async fn create_order_s2l_exo(
+  #[allow(clippy::unused_async)] // async for surface uniformity; see stable_to_lever_lst.
+  pub async fn create_order_stable_to_lever_exo(
     &self,
     collateral_mint: Pubkey,
     nonce: u64,
@@ -117,11 +117,11 @@ impl TriggerOrdersClient {
       collateral_mint,
       nonce,
     );
-    let ix = instruction_builders::create_order_s2l_exo(
+    let ix = instruction_builders::create_order_stable_to_lever_exo(
       owner,
       order,
       collateral_mint,
-      &args::CreateOrderS2lExo {
+      &args::CreateOrderStableToLeverExo {
         nonce,
         escrow_amount,
         trigger_price,
@@ -136,8 +136,8 @@ impl TriggerOrdersClient {
   ///
   /// # Errors
   /// * Failed to build transaction instructions
-  #[allow(clippy::unused_async)] // async for surface uniformity; see s2l_lst.
-  pub async fn create_order_l2s_lst(
+  #[allow(clippy::unused_async)] // async for surface uniformity; see stable_to_lever_lst.
+  pub async fn create_order_lever_to_stable_lst(
     &self,
     nonce: u64,
     escrow_amount: u64,
@@ -148,10 +148,10 @@ impl TriggerOrdersClient {
     let owner = self.keypair.pubkey();
     let (order, _) =
       pda::trigger_order_lst(owner, ConvertDirection::LeverToStable, nonce);
-    let ix = instruction_builders::create_order_l2s_lst(
+    let ix = instruction_builders::create_order_lever_to_stable_lst(
       owner,
       order,
-      &args::CreateOrderL2sLst {
+      &args::CreateOrderLeverToStableLst {
         nonce,
         escrow_amount,
         trigger_price,
@@ -166,8 +166,8 @@ impl TriggerOrdersClient {
   ///
   /// # Errors
   /// * Failed to build transaction instructions
-  #[allow(clippy::unused_async)] // async for surface uniformity; see s2l_lst.
-  pub async fn create_order_l2s_exo(
+  #[allow(clippy::unused_async)] // async for surface uniformity; see stable_to_lever_lst.
+  pub async fn create_order_lever_to_stable_exo(
     &self,
     collateral_mint: Pubkey,
     nonce: u64,
@@ -183,11 +183,11 @@ impl TriggerOrdersClient {
       collateral_mint,
       nonce,
     );
-    let ix = instruction_builders::create_order_l2s_exo(
+    let ix = instruction_builders::create_order_lever_to_stable_exo(
       owner,
       order,
       collateral_mint,
-      &args::CreateOrderL2sExo {
+      &args::CreateOrderLeverToStableExo {
         nonce,
         escrow_amount,
         trigger_price,
@@ -198,14 +198,15 @@ impl TriggerOrdersClient {
     Ok(VersionedTransactionData::one(ix))
   }
 
-  /// Cancel an s2l trigger order. Refunds HYUSD escrow + executor tip to
-  /// the owner via Anchor's `close = owner`. Handles both LST and EXO s2l
-  /// (the s2l escrow is always HYUSD), selected by `pair_target`.
+  /// Cancel a stable-to-lever trigger order. Refunds HYUSD escrow + executor
+  /// tip to the owner via Anchor's `close = owner`. Handles both LST and EXO
+  /// stable-to-lever (the stable-to-lever escrow is always HYUSD), selected by
+  /// `pair_target`.
   ///
   /// # Errors
   /// * Failed to build transaction instructions
-  #[allow(clippy::unused_async)] // async for surface uniformity; see s2l_lst.
-  pub async fn cancel_order_s2l(
+  #[allow(clippy::unused_async)] // async for surface uniformity; see stable_to_lever_lst.
+  pub async fn cancel_order_stable_to_lever(
     &self,
     nonce: u64,
     pair_target: PairTarget,
@@ -222,41 +223,42 @@ impl TriggerOrdersClient {
         nonce,
       ),
     };
-    let ix = instruction_builders::cancel_order_s2l(
+    let ix = instruction_builders::cancel_order_stable_to_lever(
       owner,
       order,
-      &args::CancelOrderS2l {},
+      &args::CancelOrderStableToLever {},
     );
     Ok(VersionedTransactionData::one(ix))
   }
 
-  /// Cancel an l2s LST order. Refunds xSOL escrow + tip via `close = owner`.
+  /// Cancel a lever-to-stable LST order. Refunds xSOL escrow + tip via
+  /// `close = owner`.
   ///
   /// # Errors
   /// * Failed to build transaction instructions
-  #[allow(clippy::unused_async)] // async for surface uniformity; see s2l_lst.
-  pub async fn cancel_order_l2s_lst(
+  #[allow(clippy::unused_async)] // async for surface uniformity; see stable_to_lever_lst.
+  pub async fn cancel_order_lever_to_stable_lst(
     &self,
     nonce: u64,
   ) -> Result<VersionedTransactionData> {
     let owner = self.keypair.pubkey();
     let (order, _) =
       pda::trigger_order_lst(owner, ConvertDirection::LeverToStable, nonce);
-    let ix = instruction_builders::cancel_order_l2s_lst(
+    let ix = instruction_builders::cancel_order_lever_to_stable_lst(
       owner,
       order,
-      &args::CancelOrderL2sLst {},
+      &args::CancelOrderLeverToStableLst {},
     );
     Ok(VersionedTransactionData::one(ix))
   }
 
-  /// Cancel an l2s EXO order. Refunds the per-collateral levercoin escrow +
-  /// tip.
+  /// Cancel a lever-to-stable EXO order. Refunds the per-collateral levercoin
+  /// escrow + tip.
   ///
   /// # Errors
   /// * Failed to build transaction instructions
-  #[allow(clippy::unused_async)] // async for surface uniformity; see s2l_lst.
-  pub async fn cancel_order_l2s_exo(
+  #[allow(clippy::unused_async)] // async for surface uniformity; see stable_to_lever_lst.
+  pub async fn cancel_order_lever_to_stable_exo(
     &self,
     collateral_mint: Pubkey,
     nonce: u64,
@@ -268,11 +270,11 @@ impl TriggerOrdersClient {
       collateral_mint,
       nonce,
     );
-    let ix = instruction_builders::cancel_order_l2s_exo(
+    let ix = instruction_builders::cancel_order_lever_to_stable_exo(
       owner,
       order,
       collateral_mint,
-      &args::CancelOrderL2sExo {},
+      &args::CancelOrderLeverToStableExo {},
     );
     Ok(VersionedTransactionData::one(ix))
   }
@@ -283,7 +285,7 @@ impl TriggerOrdersClient {
   /// # Errors
   /// * RPC error fetching `Hylo`
   /// * Account deserialization failure
-  pub async fn execute_order_s2l_lst(
+  pub async fn execute_order_stable_to_lever_lst(
     &self,
     owner: Pubkey,
     nonce: u64,
@@ -292,7 +294,7 @@ impl TriggerOrdersClient {
     let (order, _) =
       pda::trigger_order_lst(owner, ConvertDirection::StableToLever, nonce);
     let hylo: Hylo = self.program.account(pda::HYLO).await?;
-    let ix = instruction_builders::execute_order_s2l_lst(
+    let ix = instruction_builders::execute_order_stable_to_lever_lst(
       executor, owner, order, &hylo,
     );
     Ok(
@@ -301,12 +303,12 @@ impl TriggerOrdersClient {
     )
   }
 
-  /// As `execute_order_s2l_lst`, but lever→stable.
+  /// As `execute_order_stable_to_lever_lst`, but lever→stable.
   ///
   /// # Errors
   /// * RPC error fetching `Hylo`
   /// * Account deserialization failure
-  pub async fn execute_order_l2s_lst(
+  pub async fn execute_order_lever_to_stable_lst(
     &self,
     owner: Pubkey,
     nonce: u64,
@@ -315,7 +317,7 @@ impl TriggerOrdersClient {
     let (order, _) =
       pda::trigger_order_lst(owner, ConvertDirection::LeverToStable, nonce);
     let hylo: Hylo = self.program.account(pda::HYLO).await?;
-    let ix = instruction_builders::execute_order_l2s_lst(
+    let ix = instruction_builders::execute_order_lever_to_stable_lst(
       executor, owner, order, &hylo,
     );
     Ok(
@@ -330,7 +332,7 @@ impl TriggerOrdersClient {
   /// # Errors
   /// * RPC error fetching `Hylo`/`ExoPair`
   /// * Account deserialization failure
-  pub async fn execute_order_s2l_exo(
+  pub async fn execute_order_stable_to_lever_exo(
     &self,
     owner: Pubkey,
     collateral_mint: Pubkey,
@@ -348,7 +350,7 @@ impl TriggerOrdersClient {
     let hylo: Hylo = self.program.account(pda::HYLO).await?;
     let exo_pair: ExoPair =
       self.program.account(pda::exo_pair(collateral_mint)).await?;
-    let ix = instruction_builders::execute_order_s2l_exo(
+    let ix = instruction_builders::execute_order_stable_to_lever_exo(
       executor,
       owner,
       order,
@@ -362,12 +364,13 @@ impl TriggerOrdersClient {
     )
   }
 
-  /// Lever→stable EXO. See `execute_order_s2l_exo` re: the `Hylo` fetch.
+  /// Lever→stable EXO. See `execute_order_stable_to_lever_exo` re: the `Hylo`
+  /// fetch.
   ///
   /// # Errors
   /// * RPC error fetching `Hylo`/`ExoPair`
   /// * Account deserialization failure
-  pub async fn execute_order_l2s_exo(
+  pub async fn execute_order_lever_to_stable_exo(
     &self,
     owner: Pubkey,
     collateral_mint: Pubkey,
@@ -383,7 +386,7 @@ impl TriggerOrdersClient {
     let hylo: Hylo = self.program.account(pda::HYLO).await?;
     let exo_pair: ExoPair =
       self.program.account(pda::exo_pair(collateral_mint)).await?;
-    let ix = instruction_builders::execute_order_l2s_exo(
+    let ix = instruction_builders::execute_order_lever_to_stable_exo(
       executor,
       owner,
       order,
@@ -398,98 +401,98 @@ impl TriggerOrdersClient {
   }
 
   // The `simulate_execute_order_*` methods below run TWO simulations (two RPC
-  // round-trips) to extract the outer `TriggerOrderFilled` and the inner Hylo
-  // `Convert*Event` separately. This is acceptable for v1 because `simulate_*`
-  // is low-frequency (keeper pre-flight, not the hot path); it could be
-  // optimized to a single simulation later (parse both events from one result
-  // via `parse_event_filtered`, which is designed to be called repeatedly on
-  // the same result).
+  // round-trips) to extract the outer `TriggerOrderFilledEvent` and the inner
+  // Hylo `Convert*Event` separately. This is acceptable for v1 because
+  // `simulate_*` is low-frequency (keeper pre-flight, not the hot path); it
+  // could be optimized to a single simulation later (parse both events from
+  // one result via `parse_event_filtered`, which is designed to be called
+  // repeatedly on the same result).
 
   /// Simulate the execute path; return both events the chain emits on
-  /// success: the trigger-orders `TriggerOrderFilled` AND the inner Hylo
+  /// success: the trigger-orders `TriggerOrderFilledEvent` AND the inner Hylo
   /// `ConvertStableToLeverLstEvent`.
   ///
   /// # Errors
   /// Simulation failure (CPI revert, account loading, CR-gate blockers);
   /// either event missing from the simulation result.
-  pub async fn simulate_execute_order_s2l_lst(
+  pub async fn simulate_execute_order_stable_to_lever_lst(
     &self,
     owner: Pubkey,
     nonce: u64,
-  ) -> Result<(TriggerOrderFilled, ConvertStableToLeverLstEvent)> {
-    let vtd = self.execute_order_s2l_lst(owner, nonce).await?;
+  ) -> Result<(TriggerOrderFilledEvent, ConvertStableToLeverLstEvent)> {
+    let vtd = self.execute_order_stable_to_lever_lst(owner, nonce).await?;
     let user = self.keypair.pubkey();
     let vt = self.build_simulation_transaction(&user, &vtd).await?;
-    let outer: TriggerOrderFilled =
+    let outer: TriggerOrderFilledEvent =
       self.simulate_transaction_event_filtered(&vt).await?;
     let inner: ConvertStableToLeverLstEvent =
       self.simulate_transaction_event_filtered(&vt).await?;
     Ok((outer, inner))
   }
 
-  /// Simulate the execute path; return the outer `TriggerOrderFilled` and the
-  /// inner Hylo `ConvertLeverToStableLstEvent`.
+  /// Simulate the execute path; return the outer `TriggerOrderFilledEvent` and
+  /// the inner Hylo `ConvertLeverToStableLstEvent`.
   ///
   /// # Errors
   /// Simulation failure (CPI revert, account loading, CR-gate blockers);
   /// either event missing from the simulation result.
-  pub async fn simulate_execute_order_l2s_lst(
+  pub async fn simulate_execute_order_lever_to_stable_lst(
     &self,
     owner: Pubkey,
     nonce: u64,
-  ) -> Result<(TriggerOrderFilled, ConvertLeverToStableLstEvent)> {
-    let vtd = self.execute_order_l2s_lst(owner, nonce).await?;
+  ) -> Result<(TriggerOrderFilledEvent, ConvertLeverToStableLstEvent)> {
+    let vtd = self.execute_order_lever_to_stable_lst(owner, nonce).await?;
     let user = self.keypair.pubkey();
     let vt = self.build_simulation_transaction(&user, &vtd).await?;
-    let outer: TriggerOrderFilled =
+    let outer: TriggerOrderFilledEvent =
       self.simulate_transaction_event_filtered(&vt).await?;
     let inner: ConvertLeverToStableLstEvent =
       self.simulate_transaction_event_filtered(&vt).await?;
     Ok((outer, inner))
   }
 
-  /// Simulate the EXO execute path; return the outer `TriggerOrderFilled` and
-  /// the inner Hylo `ConvertStableToLeverExoEvent`.
+  /// Simulate the EXO execute path; return the outer `TriggerOrderFilledEvent`
+  /// and the inner Hylo `ConvertStableToLeverExoEvent`.
   ///
   /// # Errors
   /// Simulation failure (CPI revert, account loading, CR-gate blockers);
   /// either event missing from the simulation result.
-  pub async fn simulate_execute_order_s2l_exo(
+  pub async fn simulate_execute_order_stable_to_lever_exo(
     &self,
     owner: Pubkey,
     collateral_mint: Pubkey,
     nonce: u64,
-  ) -> Result<(TriggerOrderFilled, ConvertStableToLeverExoEvent)> {
+  ) -> Result<(TriggerOrderFilledEvent, ConvertStableToLeverExoEvent)> {
     let vtd = self
-      .execute_order_s2l_exo(owner, collateral_mint, nonce)
+      .execute_order_stable_to_lever_exo(owner, collateral_mint, nonce)
       .await?;
     let user = self.keypair.pubkey();
     let vt = self.build_simulation_transaction(&user, &vtd).await?;
-    let outer: TriggerOrderFilled =
+    let outer: TriggerOrderFilledEvent =
       self.simulate_transaction_event_filtered(&vt).await?;
     let inner: ConvertStableToLeverExoEvent =
       self.simulate_transaction_event_filtered(&vt).await?;
     Ok((outer, inner))
   }
 
-  /// Simulate the EXO execute path; return the outer `TriggerOrderFilled` and
-  /// the inner Hylo `ConvertLeverToStableExoEvent`.
+  /// Simulate the EXO execute path; return the outer `TriggerOrderFilledEvent`
+  /// and the inner Hylo `ConvertLeverToStableExoEvent`.
   ///
   /// # Errors
   /// Simulation failure (CPI revert, account loading, CR-gate blockers);
   /// either event missing from the simulation result.
-  pub async fn simulate_execute_order_l2s_exo(
+  pub async fn simulate_execute_order_lever_to_stable_exo(
     &self,
     owner: Pubkey,
     collateral_mint: Pubkey,
     nonce: u64,
-  ) -> Result<(TriggerOrderFilled, ConvertLeverToStableExoEvent)> {
+  ) -> Result<(TriggerOrderFilledEvent, ConvertLeverToStableExoEvent)> {
     let vtd = self
-      .execute_order_l2s_exo(owner, collateral_mint, nonce)
+      .execute_order_lever_to_stable_exo(owner, collateral_mint, nonce)
       .await?;
     let user = self.keypair.pubkey();
     let vt = self.build_simulation_transaction(&user, &vtd).await?;
-    let outer: TriggerOrderFilled =
+    let outer: TriggerOrderFilledEvent =
       self.simulate_transaction_event_filtered(&vt).await?;
     let inner: ConvertLeverToStableExoEvent =
       self.simulate_transaction_event_filtered(&vt).await?;
@@ -572,7 +575,7 @@ mod tests {
   }
 
   #[tokio::test]
-  async fn create_order_s2l_lst_routes_to_correct_pda() {
+  async fn create_order_stable_to_lever_lst_routes_to_correct_pda() {
     let c = TriggerOrdersClient::new_random_keypair(
       Cluster::Localnet,
       CommitmentConfig::confirmed(),
@@ -581,7 +584,13 @@ mod tests {
     let owner = c.keypair().pubkey();
 
     let tx = c
-      .create_order_s2l_lst(7, 1000, 100, -8, TriggerDirection::AtOrAbove)
+      .create_order_stable_to_lever_lst(
+        7,
+        1000,
+        100,
+        -8,
+        TriggerDirection::AtOrAbove,
+      )
       .await
       .expect("build tx");
 
@@ -595,7 +604,7 @@ mod tests {
   }
 
   #[tokio::test]
-  async fn create_order_s2l_exo_derives_with_collateral_mint() {
+  async fn create_order_stable_to_lever_exo_derives_with_collateral_mint() {
     let c = TriggerOrdersClient::new_random_keypair(
       Cluster::Localnet,
       CommitmentConfig::confirmed(),
@@ -605,7 +614,7 @@ mod tests {
     let collateral_mint = Pubkey::new_unique();
 
     let tx = c
-      .create_order_s2l_exo(
+      .create_order_stable_to_lever_exo(
         collateral_mint,
         3,
         500,
@@ -629,7 +638,7 @@ mod tests {
   }
 
   #[tokio::test]
-  async fn create_order_l2s_lst_routes_to_correct_pda() {
+  async fn create_order_lever_to_stable_lst_routes_to_correct_pda() {
     let c = TriggerOrdersClient::new_random_keypair(
       Cluster::Localnet,
       CommitmentConfig::confirmed(),
@@ -638,7 +647,13 @@ mod tests {
     let owner = c.keypair().pubkey();
 
     let tx = c
-      .create_order_l2s_lst(11, 750, 25, -8, TriggerDirection::AtOrBelow)
+      .create_order_lever_to_stable_lst(
+        11,
+        750,
+        25,
+        -8,
+        TriggerDirection::AtOrBelow,
+      )
       .await
       .expect("build tx");
 
@@ -651,7 +666,7 @@ mod tests {
   }
 
   #[tokio::test]
-  async fn create_order_l2s_exo_derives_with_collateral_mint() {
+  async fn create_order_lever_to_stable_exo_derives_with_collateral_mint() {
     let c = TriggerOrdersClient::new_random_keypair(
       Cluster::Localnet,
       CommitmentConfig::confirmed(),
@@ -660,7 +675,7 @@ mod tests {
     let owner = c.keypair().pubkey();
     let collateral_mint = Pubkey::new_unique();
     let tx = c
-      .create_order_l2s_exo(
+      .create_order_lever_to_stable_exo(
         collateral_mint,
         9,
         2_000,
@@ -684,7 +699,7 @@ mod tests {
   }
 
   #[tokio::test]
-  async fn cancel_order_s2l_lst_derives_lst_pda() {
+  async fn cancel_order_stable_to_lever_lst_derives_lst_pda() {
     let c = TriggerOrdersClient::new_random_keypair(
       Cluster::Localnet,
       CommitmentConfig::confirmed(),
@@ -693,7 +708,7 @@ mod tests {
     let owner = c.keypair().pubkey();
 
     let tx = c
-      .cancel_order_s2l(11, PairTarget::Lst)
+      .cancel_order_stable_to_lever(11, PairTarget::Lst)
       .await
       .expect("build tx");
 
@@ -707,7 +722,7 @@ mod tests {
   }
 
   #[tokio::test]
-  async fn cancel_order_s2l_exo_derives_exo_pda() {
+  async fn cancel_order_stable_to_lever_exo_derives_exo_pda() {
     let c = TriggerOrdersClient::new_random_keypair(
       Cluster::Localnet,
       CommitmentConfig::confirmed(),
@@ -717,7 +732,7 @@ mod tests {
     let collateral_mint = Pubkey::new_unique();
 
     let tx = c
-      .cancel_order_s2l(12, PairTarget::Exo { collateral_mint })
+      .cancel_order_stable_to_lever(12, PairTarget::Exo { collateral_mint })
       .await
       .expect("build tx");
 
@@ -734,7 +749,7 @@ mod tests {
   }
 
   #[tokio::test]
-  async fn cancel_order_l2s_lst_derives_pda() {
+  async fn cancel_order_lever_to_stable_lst_derives_pda() {
     let c = TriggerOrdersClient::new_random_keypair(
       Cluster::Localnet,
       CommitmentConfig::confirmed(),
@@ -742,7 +757,10 @@ mod tests {
     .unwrap();
     let owner = c.keypair().pubkey();
 
-    let tx = c.cancel_order_l2s_lst(13).await.expect("build tx");
+    let tx = c
+      .cancel_order_lever_to_stable_lst(13)
+      .await
+      .expect("build tx");
 
     assert_eq!(tx.instructions.len(), 1);
     assert_eq!(tx.instructions[0].program_id, trigger_orders::ID);
@@ -753,7 +771,7 @@ mod tests {
   }
 
   #[tokio::test]
-  async fn cancel_order_l2s_exo_derives_pda() {
+  async fn cancel_order_lever_to_stable_exo_derives_pda() {
     let c = TriggerOrdersClient::new_random_keypair(
       Cluster::Localnet,
       CommitmentConfig::confirmed(),
@@ -763,7 +781,7 @@ mod tests {
     let collateral_mint = Pubkey::new_unique();
 
     let tx = c
-      .cancel_order_l2s_exo(collateral_mint, 14)
+      .cancel_order_lever_to_stable_exo(collateral_mint, 14)
       .await
       .expect("build tx");
 

--- a/hylo-clients/src/trigger_orders_client.rs
+++ b/hylo-clients/src/trigger_orders_client.rs
@@ -8,6 +8,7 @@ use anchor_client::solana_sdk::signature::Keypair;
 use anchor_client::solana_sdk::signer::Signer;
 use anchor_client::Program;
 use anyhow::Result;
+use hylo_idl::exchange::accounts::{ExoPair, Hylo};
 use hylo_idl::trigger_orders::client::args;
 use hylo_idl::trigger_orders::instruction_builders;
 use hylo_idl::trigger_orders::types::{
@@ -16,6 +17,10 @@ use hylo_idl::trigger_orders::types::{
 use hylo_idl::{pda, trigger_orders};
 
 use crate::program_client::{ProgramClient, VersionedTransactionData};
+
+/// Conservative CU limit for `execute_order_*` per on-chain spec §6.6.
+/// Profile and tune after a first mainnet keeper run.
+pub const CONSERVATIVE_EXECUTE_CU: u32 = 400_000;
 
 /// Permissionless client for the Hylo trigger-orders program. Manages
 /// trigger-order placement, cancellation, and execution. Unlike the admin
@@ -261,6 +266,122 @@ impl TriggerOrdersClient {
     );
     Ok(VersionedTransactionData::one(ix))
   }
+
+  /// Permissionless: any signer can call. Fetches the current `Hylo`
+  /// state to thread the SOL/USD oracle, builds the CPI, prepends 400k CU.
+  ///
+  /// # Errors
+  /// RPC error; `Hylo` PDA not found; transaction build failure.
+  pub async fn execute_order_s2l_lst(
+    &self,
+    owner: Pubkey,
+    nonce: u64,
+  ) -> Result<VersionedTransactionData> {
+    let executor = self.keypair.pubkey();
+    let (order, _) =
+      pda::trigger_order_lst(owner, ConvertDirection::StableToLever, nonce);
+    let hylo: Hylo = self.program.account(pda::HYLO).await?;
+    let ix = instruction_builders::execute_order_s2l_lst(
+      executor, owner, order, &hylo,
+    );
+    Ok(
+      VersionedTransactionData::one(ix)
+        .with_compute_unit_limit(CONSERVATIVE_EXECUTE_CU),
+    )
+  }
+
+  /// As above, lever→stable LST.
+  ///
+  /// # Errors
+  /// RPC error; `Hylo` PDA not found; transaction build failure.
+  pub async fn execute_order_l2s_lst(
+    &self,
+    owner: Pubkey,
+    nonce: u64,
+  ) -> Result<VersionedTransactionData> {
+    let executor = self.keypair.pubkey();
+    let (order, _) =
+      pda::trigger_order_lst(owner, ConvertDirection::LeverToStable, nonce);
+    let hylo: Hylo = self.program.account(pda::HYLO).await?;
+    let ix = instruction_builders::execute_order_l2s_lst(
+      executor, owner, order, &hylo,
+    );
+    Ok(
+      VersionedTransactionData::one(ix)
+        .with_compute_unit_limit(CONSERVATIVE_EXECUTE_CU),
+    )
+  }
+
+  /// Stable→lever EXO. Fetches `Hylo` (for builder-signature uniformity)
+  /// and the `ExoPair` (provides the collateral oracle).
+  ///
+  /// # Errors
+  /// RPC error; `Hylo`/`ExoPair` PDA not found; transaction build failure.
+  pub async fn execute_order_s2l_exo(
+    &self,
+    owner: Pubkey,
+    collateral_mint: Pubkey,
+    nonce: u64,
+  ) -> Result<VersionedTransactionData> {
+    let executor = self.keypair.pubkey();
+    let (order, _) = pda::trigger_order_exo(
+      owner,
+      ConvertDirection::StableToLever,
+      collateral_mint,
+      nonce,
+    );
+    // `Hylo` is fetched to satisfy the (uniform) execute-builder signature;
+    // the EXO CPI takes its oracle from `ExoPair`, not `Hylo`.
+    let hylo: Hylo = self.program.account(pda::HYLO).await?;
+    let exo_pair: ExoPair =
+      self.program.account(pda::exo_pair(collateral_mint)).await?;
+    let ix = instruction_builders::execute_order_s2l_exo(
+      executor,
+      owner,
+      order,
+      collateral_mint,
+      &hylo,
+      &exo_pair,
+    );
+    Ok(
+      VersionedTransactionData::one(ix)
+        .with_compute_unit_limit(CONSERVATIVE_EXECUTE_CU),
+    )
+  }
+
+  /// Lever→stable EXO. See `execute_order_s2l_exo` re: the `Hylo` fetch.
+  ///
+  /// # Errors
+  /// RPC error; `Hylo`/`ExoPair` PDA not found; transaction build failure.
+  pub async fn execute_order_l2s_exo(
+    &self,
+    owner: Pubkey,
+    collateral_mint: Pubkey,
+    nonce: u64,
+  ) -> Result<VersionedTransactionData> {
+    let executor = self.keypair.pubkey();
+    let (order, _) = pda::trigger_order_exo(
+      owner,
+      ConvertDirection::LeverToStable,
+      collateral_mint,
+      nonce,
+    );
+    let hylo: Hylo = self.program.account(pda::HYLO).await?;
+    let exo_pair: ExoPair =
+      self.program.account(pda::exo_pair(collateral_mint)).await?;
+    let ix = instruction_builders::execute_order_l2s_exo(
+      executor,
+      owner,
+      order,
+      collateral_mint,
+      &hylo,
+      &exo_pair,
+    );
+    Ok(
+      VersionedTransactionData::one(ix)
+        .with_compute_unit_limit(CONSERVATIVE_EXECUTE_CU),
+    )
+  }
 }
 
 #[cfg(test)]
@@ -273,6 +394,11 @@ mod tests {
   };
 
   use super::*;
+
+  #[test]
+  fn cu_constant_is_400k() {
+    assert_eq!(CONSERVATIVE_EXECUTE_CU, 400_000);
+  }
 
   #[test]
   fn client_id_matches_trigger_orders_program_id() {

--- a/hylo-clients/src/trigger_orders_client.rs
+++ b/hylo-clients/src/trigger_orders_client.rs
@@ -13,6 +13,7 @@ use hylo_idl::exchange::events::{
   ConvertLeverToStableExoEvent, ConvertLeverToStableLstEvent,
   ConvertStableToLeverExoEvent, ConvertStableToLeverLstEvent,
 };
+use hylo_idl::trigger_orders::accounts::TriggerOrder;
 use hylo_idl::trigger_orders::client::args;
 use hylo_idl::trigger_orders::events::TriggerOrderFilled;
 use hylo_idl::trigger_orders::instruction_builders;
@@ -485,6 +486,48 @@ impl TriggerOrdersClient {
     let inner: ConvertLeverToStableExoEvent =
       self.simulate_transaction_event_filtered(&vt).await?;
     Ok((outer, inner))
+  }
+
+  /// Fetch a single open `TriggerOrder` by deriving its PDA. Returns
+  /// `Ok(None)` if the PDA doesn't exist (e.g. already cancelled/executed).
+  ///
+  /// # Errors
+  /// RPC error other than account-not-found.
+  pub async fn get_order(
+    &self,
+    owner: Pubkey,
+    direction: ConvertDirection,
+    pair_target: PairTarget,
+    nonce: u64,
+  ) -> Result<Option<TriggerOrder>> {
+    let (pda_pubkey, _) = match pair_target {
+      PairTarget::Lst => pda::trigger_order_lst(owner, direction, nonce),
+      PairTarget::Exo { collateral_mint } => {
+        pda::trigger_order_exo(owner, direction, collateral_mint, nonce)
+      }
+    };
+    match self.program.account::<TriggerOrder>(pda_pubkey).await {
+      Ok(o) => Ok(Some(o)),
+      Err(anchor_client::ClientError::AccountNotFound) => Ok(None),
+      Err(e) => Err(e.into()),
+    }
+  }
+
+  /// List all open orders for an owner via `getProgramAccounts` with a
+  /// memcmp filter at `TriggerOrder::OWNER_OFFSET`.
+  ///
+  /// # Errors
+  /// RPC error.
+  pub async fn list_orders_by_owner(
+    &self,
+    owner: Pubkey,
+  ) -> Result<Vec<(Pubkey, TriggerOrder)>> {
+    use solana_rpc_client_api::filter::{Memcmp, RpcFilterType};
+    let filters = vec![RpcFilterType::Memcmp(Memcmp::new_raw_bytes(
+      TriggerOrder::OWNER_OFFSET,
+      owner.to_bytes().to_vec(),
+    ))];
+    Ok(self.program.accounts::<TriggerOrder>(filters).await?)
   }
 }
 

--- a/hylo-clients/src/util.rs
+++ b/hylo-clients/src/util.rs
@@ -103,6 +103,47 @@ where
   }
 }
 
+/// Like [`parse_event`], but filters inner instructions by event
+/// discriminator BEFORE picking. Safe to call multiple times on the same
+/// simulation result with different `E` to extract distinct events from
+/// the same tx (e.g., a trigger-orders fill event + its inner Hylo
+/// convert event).
+///
+/// `parse_event` takes the FIRST `PartiallyDecoded` inner instruction and
+/// only then checks the discriminator, so it cannot extract a second,
+/// differently-typed event from the same result. This variant filters by
+/// `E::DISCRIMINATOR` first, then picks the first match.
+///
+/// # Errors
+/// * Simulation contains a tx-level error
+/// * No inner instructions returned
+/// * No event matching `E::DISCRIMINATOR` found, or deserialization fails
+pub fn parse_event_filtered<E>(
+  result: &Response<RpcSimulateTransactionResult>,
+) -> Result<E>
+where
+  E: AnchorDeserialize + Discriminator,
+{
+  if let Some(err) = &result.value.err {
+    bail!("Simulation failed: {err:?}")
+  }
+  let Some(ixs) = &result.value.inner_instructions else {
+    bail!("Simulation succeeded but no inner instructions returned")
+  };
+  ixs
+    .iter()
+    .flat_map(|ix| &ix.instructions)
+    .filter_map(|ix| match ix {
+      UiInstruction::Parsed(UiParsedInstruction::PartiallyDecoded(
+        UiPartiallyDecodedInstruction { data, .. },
+      )) => bs58::decode(data).into_vec().ok(),
+      _ => None,
+    })
+    .filter(|bytes| bytes.len() >= 16 && &bytes[8..16] == E::DISCRIMINATOR)
+    .find_map(|bytes| E::try_from_slice(&bytes[16..]).ok())
+    .context("Could not parse event from result")
+}
+
 /// Deserializes an account into an address lookup table.
 ///
 /// # Errors
@@ -236,4 +277,154 @@ pub fn build_test_router_client() -> Result<RouterClient> {
 #[must_use]
 pub fn user_ata_instruction(user: &Pubkey, mint: &Pubkey) -> Instruction {
   create_associated_token_account_idempotent(user, user, mint, &token::ID)
+}
+
+#[cfg(test)]
+mod parse_event_filtered_tests {
+  use anchor_lang::{AnchorSerialize, Discriminator};
+  use hylo_idl::exchange::events::ConvertStableToLeverLstEvent;
+  use hylo_idl::trigger_orders::events::TriggerOrderFilled;
+  use hylo_idl::trigger_orders::types::{
+    ConvertDirection, PairTarget, TriggerDirection,
+  };
+  use solana_rpc_client_api::response::{
+    RpcResponseContext, RpcSimulateTransactionResult,
+  };
+  use solana_transaction_status_client_types::UiInnerInstructions;
+
+  use super::*;
+
+  /// Encodes an event the way an Anchor event-CPI inner instruction carries
+  /// it on the wire: `[8-byte self-CPI discriminator][8-byte event
+  /// discriminator][borsh(event)]`, then base58 (as the JSON RPC returns it).
+  fn encode_event<E: AnchorSerialize + Discriminator>(event: &E) -> String {
+    // The first 8 bytes are the Anchor event-CPI self-discriminator. Their
+    // exact value is irrelevant to parsing (`parse_event*` only reads
+    // `bytes[8..16]` for the event discriminator), so we use a sentinel.
+    let mut bytes = vec![0xAB_u8; 8];
+    bytes.extend_from_slice(E::DISCRIMINATOR);
+    bytes.extend_from_slice(&event.try_to_vec().expect("borsh serialize"));
+    bs58::encode(bytes).into_string()
+  }
+
+  fn partially_decoded(data: String) -> UiInstruction {
+    UiInstruction::Parsed(UiParsedInstruction::PartiallyDecoded(
+      UiPartiallyDecodedInstruction {
+        program_id: Pubkey::new_unique().to_string(),
+        accounts: vec![],
+        data,
+        stack_height: None,
+      },
+    ))
+  }
+
+  /// Builds a simulation response carrying the two given inner-instruction
+  /// data blobs, mirroring a real `execute_order_*` tx that emits both a
+  /// `TriggerOrderFilled` and an inner Hylo convert event.
+  fn response_with(
+    blobs: Vec<String>,
+  ) -> Response<RpcSimulateTransactionResult> {
+    Response {
+      context: RpcResponseContext {
+        slot: 0,
+        api_version: None,
+      },
+      value: RpcSimulateTransactionResult {
+        err: None,
+        logs: None,
+        accounts: None,
+        units_consumed: None,
+        loaded_accounts_data_size: None,
+        return_data: None,
+        inner_instructions: Some(vec![UiInnerInstructions {
+          index: 0,
+          instructions: blobs.into_iter().map(partially_decoded).collect(),
+        }]),
+        replacement_blockhash: None,
+      },
+    }
+  }
+
+  fn sample_trigger_order_filled() -> TriggerOrderFilled {
+    TriggerOrderFilled {
+      order: Pubkey::new_unique(),
+      owner: Pubkey::new_unique(),
+      executor: Pubkey::new_unique(),
+      pair_target: PairTarget::Lst,
+      convert_direction: ConvertDirection::StableToLever,
+      nonce: 42,
+      escrow_spent: 1_000,
+      output_received: hylo_idl::trigger_orders::types::UFixValue64 {
+        bits: 2_000,
+        exp: -6,
+      },
+      output_mint: Pubkey::new_unique(),
+      trigger_price: 100,
+      trigger_expo: -8,
+      direction: TriggerDirection::AtOrAbove,
+      pyth_price: 123,
+      pyth_expo: -8,
+    }
+  }
+
+  fn sample_convert_event() -> ConvertStableToLeverLstEvent {
+    use hylo_idl::exchange::types::UFixValue64;
+    ConvertStableToLeverLstEvent {
+      stablecoin_burned: UFixValue64 { bits: 10, exp: -6 },
+      stablecoin_fees: UFixValue64 { bits: 1, exp: -6 },
+      stablecoin_nav: UFixValue64 { bits: 100, exp: -6 },
+      levercoin_minted: UFixValue64 { bits: 5, exp: -6 },
+      levercoin_nav: UFixValue64 { bits: 200, exp: -6 },
+    }
+  }
+
+  // The crux of Task 17: a single `execute_order_*` simulation result carries
+  // TWO differently-typed events. `parse_event_filtered` must extract BOTH
+  // from the SAME result by filtering on the discriminator before picking —
+  // something the existing `parse_event` (first-ix-then-filter) cannot do.
+  #[test]
+  fn extracts_two_distinct_events_from_one_result() {
+    let filled = sample_trigger_order_filled();
+    let convert = sample_convert_event();
+    let resp =
+      response_with(vec![encode_event(&filled), encode_event(&convert)]);
+
+    let got_filled: TriggerOrderFilled =
+      parse_event_filtered(&resp).expect("TriggerOrderFilled extractable");
+    let got_convert: ConvertStableToLeverLstEvent =
+      parse_event_filtered(&resp).expect("convert event extractable");
+
+    // Assert on distinguishing fields (generated event structs do not
+    // necessarily derive PartialEq/Debug, so compare field-by-field).
+    assert_eq!(got_filled.nonce, 42);
+    assert_eq!(got_filled.escrow_spent, 1_000);
+    assert_eq!(got_filled.output_received.bits, 2_000);
+    assert_eq!(got_convert.stablecoin_burned.bits, 10);
+    assert_eq!(got_convert.levercoin_nav.bits, 200);
+  }
+
+  // Order-independence: extraction works regardless of which event appears
+  // first in the inner-instruction list (the inner convert event precedes
+  // the outer fill event in the on-wire CPI order).
+  #[test]
+  fn extracts_when_target_event_is_not_first() {
+    let filled = sample_trigger_order_filled();
+    let convert = sample_convert_event();
+    // Convert event first, fill event second.
+    let resp =
+      response_with(vec![encode_event(&convert), encode_event(&filled)]);
+
+    let got_filled: TriggerOrderFilled =
+      parse_event_filtered(&resp).expect("fill event still extractable");
+    assert_eq!(got_filled.nonce, 42);
+  }
+
+  #[test]
+  fn errors_when_event_absent() {
+    let convert = sample_convert_event();
+    let resp = response_with(vec![encode_event(&convert)]);
+    // No TriggerOrderFilled present → must error, not silently succeed.
+    let result: Result<TriggerOrderFilled> = parse_event_filtered(&resp);
+    assert!(result.is_err());
+  }
 }

--- a/hylo-clients/src/util.rs
+++ b/hylo-clients/src/util.rs
@@ -287,7 +287,7 @@ pub fn user_ata_instruction(user: &Pubkey, mint: &Pubkey) -> Instruction {
 mod parse_event_filtered_tests {
   use anchor_lang::{AnchorSerialize, Discriminator};
   use hylo_idl::exchange::events::ConvertStableToLeverLstEvent;
-  use hylo_idl::trigger_orders::events::TriggerOrderFilled;
+  use hylo_idl::trigger_orders::events::TriggerOrderFilledEvent;
   use hylo_idl::trigger_orders::types::{
     ConvertDirection, PairTarget, TriggerDirection,
   };
@@ -324,7 +324,7 @@ mod parse_event_filtered_tests {
 
   /// Builds a simulation response carrying the two given inner-instruction
   /// data blobs, mirroring a real `execute_order_*` tx that emits both a
-  /// `TriggerOrderFilled` and an inner Hylo convert event.
+  /// `TriggerOrderFilledEvent` and an inner Hylo convert event.
   fn response_with(
     blobs: Vec<String>,
   ) -> Response<RpcSimulateTransactionResult> {
@@ -349,8 +349,8 @@ mod parse_event_filtered_tests {
     }
   }
 
-  fn sample_trigger_order_filled() -> TriggerOrderFilled {
-    TriggerOrderFilled {
+  fn sample_trigger_order_filled() -> TriggerOrderFilledEvent {
+    TriggerOrderFilledEvent {
       order: Pubkey::new_unique(),
       owner: Pubkey::new_unique(),
       executor: Pubkey::new_unique(),
@@ -393,8 +393,8 @@ mod parse_event_filtered_tests {
     let resp =
       response_with(vec![encode_event(&filled), encode_event(&convert)]);
 
-    let got_filled: TriggerOrderFilled =
-      parse_event_filtered(&resp).expect("TriggerOrderFilled extractable");
+    let got_filled: TriggerOrderFilledEvent =
+      parse_event_filtered(&resp).expect("TriggerOrderFilledEvent extractable");
     let got_convert: ConvertStableToLeverLstEvent =
       parse_event_filtered(&resp).expect("convert event extractable");
 
@@ -418,7 +418,7 @@ mod parse_event_filtered_tests {
     let resp =
       response_with(vec![encode_event(&convert), encode_event(&filled)]);
 
-    let got_filled: TriggerOrderFilled =
+    let got_filled: TriggerOrderFilledEvent =
       parse_event_filtered(&resp).expect("fill event still extractable");
     assert_eq!(got_filled.nonce, 42);
   }
@@ -427,14 +427,15 @@ mod parse_event_filtered_tests {
   fn errors_when_event_absent() {
     let convert = sample_convert_event();
     let resp = response_with(vec![encode_event(&convert)]);
-    // No TriggerOrderFilled present → must error, not silently succeed.
-    let result: Result<TriggerOrderFilled> = parse_event_filtered(&resp);
+    // No TriggerOrderFilledEvent present → must error, not silently succeed.
+    let result: Result<TriggerOrderFilledEvent> = parse_event_filtered(&resp);
     assert!(result.is_err());
   }
 
   /// A discriminator-MATCHING but undeserializable blob: the correct event
   /// discriminator followed by a payload too short to borsh-decode (the first
-  /// field of `TriggerOrderFilled` is a 32-byte `Pubkey`, so 3 bytes fail).
+  /// field of `TriggerOrderFilledEvent` is a 32-byte `Pubkey`, so 3 bytes
+  /// fail).
   fn corrupt_blob<E: Discriminator>() -> String {
     let mut bytes = vec![0xAB_u8; 8];
     bytes.extend_from_slice(E::DISCRIMINATOR);
@@ -450,11 +451,11 @@ mod parse_event_filtered_tests {
   fn skips_discriminator_match_that_fails_to_deserialize() {
     let valid = sample_trigger_order_filled();
     let resp = response_with(vec![
-      corrupt_blob::<TriggerOrderFilled>(),
+      corrupt_blob::<TriggerOrderFilledEvent>(),
       encode_event(&valid),
     ]);
 
-    let got: TriggerOrderFilled = parse_event_filtered(&resp)
+    let got: TriggerOrderFilledEvent = parse_event_filtered(&resp)
       .expect("skips the corrupt match and returns the valid one");
     assert_eq!(got.nonce, 42);
   }

--- a/hylo-clients/src/util.rs
+++ b/hylo-clients/src/util.rs
@@ -431,4 +431,31 @@ mod parse_event_filtered_tests {
     let result: Result<TriggerOrderFilled> = parse_event_filtered(&resp);
     assert!(result.is_err());
   }
+
+  /// A discriminator-MATCHING but undeserializable blob: the correct event
+  /// discriminator followed by a payload too short to borsh-decode (the first
+  /// field of `TriggerOrderFilled` is a 32-byte `Pubkey`, so 3 bytes fail).
+  fn corrupt_blob<E: Discriminator>() -> String {
+    let mut bytes = vec![0xAB_u8; 8];
+    bytes.extend_from_slice(E::DISCRIMINATOR);
+    bytes.extend_from_slice(&[0x00, 0x01, 0x02]);
+    bs58::encode(bytes).into_string()
+  }
+
+  // `parse_event_filtered` must SKIP an inner instruction whose discriminator
+  // matches `E` but whose payload fails to deserialize, and keep scanning for
+  // a valid match — the documented divergence from `parse_event` (which
+  // propagates the borsh error). Here a corrupt match precedes a valid one.
+  #[test]
+  fn skips_discriminator_match_that_fails_to_deserialize() {
+    let valid = sample_trigger_order_filled();
+    let resp = response_with(vec![
+      corrupt_blob::<TriggerOrderFilled>(),
+      encode_event(&valid),
+    ]);
+
+    let got: TriggerOrderFilled = parse_event_filtered(&resp)
+      .expect("skips the corrupt match and returns the valid one");
+    assert_eq!(got.nonce, 42);
+  }
 }

--- a/hylo-clients/src/util.rs
+++ b/hylo-clients/src/util.rs
@@ -114,6 +114,10 @@ where
 /// differently-typed event from the same result. This variant filters by
 /// `E::DISCRIMINATOR` first, then picks the first match.
 ///
+/// Note: an instruction whose discriminator matches `E::DISCRIMINATOR` but
+/// whose payload fails to deserialize is SKIPPED (not surfaced as an error),
+/// unlike `parse_event`, which propagates the borsh error.
+///
 /// # Errors
 /// * Simulation contains a tx-level error
 /// * No inner instructions returned

--- a/hylo-idl/idls/hylo_trigger_orders.json
+++ b/hylo-idl/idls/hylo_trigger_orders.json
@@ -5492,18 +5492,6 @@
           {
             "name": "bump",
             "type": "u8"
-          },
-          {
-            "name": "_reserved",
-            "docs": [
-              "Reserved for forward-compatible field additions without a migration."
-            ],
-            "type": {
-              "array": [
-                "u8",
-                64
-              ]
-            }
           }
         ]
       }

--- a/hylo-idl/idls/hylo_trigger_orders.json
+++ b/hylo-idl/idls/hylo_trigger_orders.json
@@ -8,16 +8,16 @@
   },
   "instructions": [
     {
-      "name": "cancel_order_l2s_exo",
+      "name": "cancel_order_lever_to_stable_exo",
       "discriminator": [
-        61,
-        165,
-        75,
-        198,
-        91,
-        170,
-        235,
-        153
+        47,
+        127,
+        17,
+        226,
+        125,
+        19,
+        22,
+        80
       ],
       "accounts": [
         {
@@ -239,21 +239,21 @@
       "args": [],
       "returns": {
         "defined": {
-          "name": "TriggerOrderCancelled"
+          "name": "TriggerOrderCancelledEvent"
         }
       }
     },
     {
-      "name": "cancel_order_l2s_lst",
+      "name": "cancel_order_lever_to_stable_lst",
       "discriminator": [
-        121,
-        201,
-        137,
-        113,
-        147,
-        216,
-        109,
-        177
+        68,
+        60,
+        120,
+        236,
+        126,
+        232,
+        1,
+        22
       ],
       "accounts": [
         {
@@ -455,21 +455,21 @@
       "args": [],
       "returns": {
         "defined": {
-          "name": "TriggerOrderCancelled"
+          "name": "TriggerOrderCancelledEvent"
         }
       }
     },
     {
-      "name": "cancel_order_s2l",
+      "name": "cancel_order_stable_to_lever",
       "discriminator": [
-        85,
-        20,
-        75,
-        12,
-        198,
-        159,
-        196,
-        50
+        45,
+        2,
+        38,
+        191,
+        74,
+        153,
+        31,
+        179
       ],
       "accounts": [
         {
@@ -672,21 +672,21 @@
       "args": [],
       "returns": {
         "defined": {
-          "name": "TriggerOrderCancelled"
+          "name": "TriggerOrderCancelledEvent"
         }
       }
     },
     {
-      "name": "create_order_l2s_exo",
+      "name": "create_order_lever_to_stable_exo",
       "discriminator": [
-        145,
-        7,
-        163,
-        2,
-        20,
-        124,
-        128,
-        146
+        18,
+        5,
+        47,
+        137,
+        57,
+        87,
+        9,
+        108
       ],
       "accounts": [
         {
@@ -923,8 +923,9 @@
             "above), so a malformed mint creates a PDA at an address unique to that",
             "owner/nonce/mint triple. No collision risk with other orders.",
             "2. Only the owner is harmed by an unfillable order — their levercoin goes",
-            "into a PDA they alone can drain via `cancel_order_l2s_exo`. There's no",
-            "path for an attacker to lock anyone else's funds via this vector.",
+            "into a PDA they alone can drain via",
+            "`cancel_order_lever_to_stable_exo`. There's no path for an attacker to",
+            "lock anyone else's funds via this vector.",
             "3. The cancel path doesn't read `ExoPair`, `Hylo`, or any pair-specific",
             "state. So even if Hylo deprecates this collateral, the owner can",
             "always recover. Funds-recoverability is structural, not policy.",
@@ -1011,21 +1012,21 @@
       ],
       "returns": {
         "defined": {
-          "name": "TriggerOrderCreated"
+          "name": "TriggerOrderCreatedEvent"
         }
       }
     },
     {
-      "name": "create_order_l2s_lst",
+      "name": "create_order_lever_to_stable_lst",
       "discriminator": [
-        217,
-        157,
-        106,
-        121,
-        230,
-        232,
-        238,
-        73
+        169,
+        244,
+        48,
+        59,
+        91,
+        86,
+        47,
+        4
       ],
       "accounts": [
         {
@@ -1295,21 +1296,21 @@
       ],
       "returns": {
         "defined": {
-          "name": "TriggerOrderCreated"
+          "name": "TriggerOrderCreatedEvent"
         }
       }
     },
     {
-      "name": "create_order_s2l_exo",
+      "name": "create_order_stable_to_lever_exo",
       "discriminator": [
+        64,
+        253,
+        226,
+        234,
         102,
-        197,
-        120,
-        21,
-        57,
-        139,
-        195,
-        202
+        182,
+        158,
+        44
       ],
       "accounts": [
         {
@@ -1534,8 +1535,9 @@
             "above), so a malformed mint creates a PDA at an address unique to that",
             "owner/nonce/mint triple. No collision risk with other orders.",
             "2. Only the owner is harmed by an unfillable order — their HYUSD goes",
-            "into a PDA they alone can drain via `cancel_order_s2l`. There's no",
-            "path for an attacker to lock anyone else's funds via this vector.",
+            "into a PDA they alone can drain via `cancel_order_stable_to_lever`.",
+            "There's no path for an attacker to lock anyone else's funds via this",
+            "vector.",
             "3. The cancel path doesn't read `ExoPair`, `Hylo`, or any pair-specific",
             "state. So even if Hylo deprecates this collateral, the owner can",
             "always recover. Funds-recoverability is structural, not policy.",
@@ -1622,21 +1624,21 @@
       ],
       "returns": {
         "defined": {
-          "name": "TriggerOrderCreated"
+          "name": "TriggerOrderCreatedEvent"
         }
       }
     },
     {
-      "name": "create_order_s2l_lst",
+      "name": "create_order_stable_to_lever_lst",
       "discriminator": [
-        1,
-        195,
-        39,
-        158,
-        147,
-        192,
-        10,
-        101
+        44,
+        239,
+        230,
+        43,
+        167,
+        109,
+        159,
+        75
       ],
       "accounts": [
         {
@@ -1907,21 +1909,21 @@
       ],
       "returns": {
         "defined": {
-          "name": "TriggerOrderCreated"
+          "name": "TriggerOrderCreatedEvent"
         }
       }
     },
     {
-      "name": "execute_order_l2s_exo",
+      "name": "execute_order_lever_to_stable_exo",
       "discriminator": [
-        112,
-        175,
-        205,
-        216,
-        129,
-        95,
-        184,
-        153
+        37,
+        208,
+        145,
+        18,
+        1,
+        120,
+        209,
+        189
       ],
       "accounts": [
         {
@@ -2606,21 +2608,21 @@
       "args": [],
       "returns": {
         "defined": {
-          "name": "TriggerOrderFilled"
+          "name": "TriggerOrderFilledEvent"
         }
       }
     },
     {
-      "name": "execute_order_l2s_lst",
+      "name": "execute_order_lever_to_stable_lst",
       "discriminator": [
-        96,
-        37,
-        224,
-        31,
-        190,
-        139,
-        223,
-        0
+        148,
+        194,
+        232,
+        208,
+        165,
+        164,
+        221,
+        71
       ],
       "accounts": [
         {
@@ -3079,21 +3081,21 @@
       "args": [],
       "returns": {
         "defined": {
-          "name": "TriggerOrderFilled"
+          "name": "TriggerOrderFilledEvent"
         }
       }
     },
     {
-      "name": "execute_order_s2l_exo",
+      "name": "execute_order_stable_to_lever_exo",
       "discriminator": [
-        29,
-        184,
-        147,
-        164,
-        106,
-        9,
-        121,
-        21
+        78,
+        24,
+        242,
+        4,
+        17,
+        60,
+        133,
+        89
       ],
       "accounts": [
         {
@@ -3778,21 +3780,21 @@
       "args": [],
       "returns": {
         "defined": {
-          "name": "TriggerOrderFilled"
+          "name": "TriggerOrderFilledEvent"
         }
       }
     },
     {
-      "name": "execute_order_s2l_lst",
+      "name": "execute_order_stable_to_lever_lst",
       "discriminator": [
-        26,
-        104,
-        100,
-        203,
-        82,
-        5,
-        112,
-        58
+        225,
+        97,
+        249,
+        74,
+        99,
+        214,
+        130,
+        114
       ],
       "accounts": [
         {
@@ -4251,7 +4253,7 @@
       "args": [],
       "returns": {
         "defined": {
-          "name": "TriggerOrderFilled"
+          "name": "TriggerOrderFilledEvent"
         }
       }
     }
@@ -4312,42 +4314,42 @@
   ],
   "events": [
     {
-      "name": "TriggerOrderCancelled",
+      "name": "TriggerOrderCancelledEvent",
       "discriminator": [
-        255,
-        151,
-        206,
-        140,
-        98,
-        153,
-        223,
-        121
-      ]
-    },
-    {
-      "name": "TriggerOrderCreated",
-      "discriminator": [
-        90,
-        78,
+        178,
+        127,
         39,
-        34,
-        130,
-        168,
-        79,
-        55
+        234,
+        87,
+        193,
+        7,
+        119
       ]
     },
     {
-      "name": "TriggerOrderFilled",
+      "name": "TriggerOrderCreatedEvent",
       "discriminator": [
-        124,
-        156,
-        201,
-        86,
-        158,
-        86,
-        183,
-        212
+        231,
+        191,
+        133,
+        0,
+        130,
+        0,
+        198,
+        83
+      ]
+    },
+    {
+      "name": "TriggerOrderFilledEvent",
+      "discriminator": [
+        72,
+        131,
+        117,
+        214,
+        75,
+        219,
+        32,
+        36
       ]
     }
   ],
@@ -4355,27 +4357,27 @@
     {
       "code": 6000,
       "name": "AmountTooSmall",
-      "msg": "escrow_amount must be > 0"
+      "msg": "Escrow amount must be greater than zero."
     },
     {
       "code": 6001,
       "name": "AccountMismatch",
-      "msg": "account does not match the order's pair target"
+      "msg": "Account does not match the order's pair target."
     },
     {
       "code": 6002,
       "name": "TriggerNotMet",
-      "msg": "price condition not met"
+      "msg": "Price condition not met."
     },
     {
       "code": 6003,
       "name": "Unauthorized",
-      "msg": "signer is not the order owner"
+      "msg": "Signer is not the order owner."
     },
     {
       "code": 6004,
       "name": "InvalidPythPrice",
-      "msg": "invalid pyth price update account, feed id, or expo"
+      "msg": "Invalid Pyth price update account, feed id, or exponent."
     }
   ],
   "types": [
@@ -5125,7 +5127,8 @@
           {
             "name": "convert_direction",
             "docs": [
-              "Direction of the Hylo convert ix this order will fire (s2l or l2s)."
+              "Direction of the Hylo convert ix this order will fire",
+              "(`stable_to_lever` or `lever_to_stable`)."
             ],
             "type": {
               "defined": {
@@ -5145,7 +5148,8 @@
             "name": "escrow_amount",
             "docs": [
               "Amount escrowed in the order's escrow vault. Unit depends on",
-              "`convert_direction`: HYUSD for s2l; xSOL or per-EXO levercoin for l2s."
+              "`convert_direction`: HYUSD for `stable_to_lever`; xSOL or per-EXO",
+              "levercoin for `lever_to_stable`."
             ],
             "type": "u64"
           },
@@ -5181,15 +5185,26 @@
           {
             "name": "bump",
             "type": "u8"
+          },
+          {
+            "name": "_reserved",
+            "docs": [
+              "Reserved for forward-compatible field additions without a migration."
+            ],
+            "type": {
+              "array": [
+                "u8",
+                64
+              ]
+            }
           }
         ]
       }
     },
     {
-      "name": "TriggerOrderCancelled",
+      "name": "TriggerOrderCancelledEvent",
       "docs": [
-        "Emitted at the end of `cancel_order_{s2l,l2s_lst,l2s_exo}` after the",
-        "refund completes."
+        "Emitted at the end of `cancel_order_*` after the refund completes."
       ],
       "type": {
         "kind": "struct",
@@ -5230,10 +5245,9 @@
       }
     },
     {
-      "name": "TriggerOrderCreated",
+      "name": "TriggerOrderCreatedEvent",
       "docs": [
-        "Emitted at the end of `create_order_{s2l,l2s}_{lst,exo}` after state",
-        "mutations succeed."
+        "Emitted at the end of `create_order_*` after state mutations succeed."
       ],
       "type": {
         "kind": "struct",
@@ -5269,7 +5283,8 @@
           {
             "name": "escrow_amount",
             "docs": [
-              "Amount escrowed (HYUSD for s2l, levercoin for l2s)."
+              "Amount escrowed (HYUSD for `stable_to_lever`, levercoin for",
+              "`lever_to_stable`)."
             ],
             "type": "u64"
           },
@@ -5297,11 +5312,11 @@
       }
     },
     {
-      "name": "TriggerOrderFilled",
+      "name": "TriggerOrderFilledEvent",
       "docs": [
-        "Emitted at the end of `execute_order_{s2l,l2s}_{lst,exo}` after the order",
-        "fills. `output_received` mirrors Hylo's convert event field",
-        "(`UFixValue64`) verbatim."
+        "Emitted at the end of `execute_order_*` after the order fills.",
+        "`output_received` mirrors Hylo's convert event field (`UFixValue64`)",
+        "verbatim."
       ],
       "type": {
         "kind": "struct",
@@ -5348,8 +5363,8 @@
           {
             "name": "output_received",
             "docs": [
-              "Amount minted to the owner's output ATA (levercoin for s2l, HYUSD for",
-              "l2s)."
+              "Amount minted to the owner's output ATA (levercoin for",
+              "`stable_to_lever`, HYUSD for `lever_to_stable`)."
             ],
             "type": {
               "defined": {
@@ -5360,7 +5375,8 @@
           {
             "name": "output_mint",
             "docs": [
-              "Mint of the output token (levercoin mint for s2l, HYUSD mint for l2s)."
+              "Mint of the output token (levercoin mint for `stable_to_lever`, HYUSD",
+              "mint for `lever_to_stable`)."
             ],
             "type": "pubkey"
           },

--- a/hylo-idl/idls/hylo_trigger_orders.json
+++ b/hylo-idl/idls/hylo_trigger_orders.json
@@ -1940,7 +1940,6 @@
         },
         {
           "name": "hylo",
-          "writable": true,
           "pda": {
             "seeds": [
               {
@@ -3263,7 +3262,6 @@
         },
         {
           "name": "hylo",
-          "writable": true,
           "pda": {
             "seeds": [
               {

--- a/hylo-idl/idls/hylo_trigger_orders.json
+++ b/hylo-idl/idls/hylo_trigger_orders.json
@@ -1939,7 +1939,58 @@
           ]
         },
         {
-          "name": "hylo"
+          "name": "hylo",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  104,
+                  121,
+                  108,
+                  111
+                ]
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                245,
+                187,
+                72,
+                160,
+                4,
+                116,
+                48,
+                134,
+                197,
+                164,
+                152,
+                189,
+                233,
+                219,
+                27,
+                124,
+                201,
+                65,
+                103,
+                243,
+                58,
+                82,
+                140,
+                90,
+                13,
+                150,
+                83,
+                40,
+                223,
+                158,
+                124,
+                33
+              ]
+            }
+          }
         },
         {
           "name": "exo_pair",
@@ -2639,7 +2690,57 @@
         },
         {
           "name": "hylo",
-          "writable": true
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  104,
+                  121,
+                  108,
+                  111
+                ]
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                245,
+                187,
+                72,
+                160,
+                4,
+                116,
+                48,
+                134,
+                197,
+                164,
+                152,
+                189,
+                233,
+                219,
+                27,
+                124,
+                201,
+                65,
+                103,
+                243,
+                58,
+                82,
+                140,
+                90,
+                13,
+                150,
+                83,
+                40,
+                223,
+                158,
+                124,
+                33
+              ]
+            }
+          }
         },
         {
           "name": "sol_usd_pyth_feed"
@@ -2711,7 +2812,57 @@
         },
         {
           "name": "xsol_mint",
-          "writable": true
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  120,
+                  83,
+                  79,
+                  76
+                ]
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                245,
+                187,
+                72,
+                160,
+                4,
+                116,
+                48,
+                134,
+                197,
+                164,
+                152,
+                189,
+                233,
+                219,
+                27,
+                124,
+                201,
+                65,
+                103,
+                243,
+                58,
+                82,
+                140,
+                90,
+                13,
+                150,
+                83,
+                40,
+                223,
+                158,
+                124,
+                33
+              ]
+            }
+          }
         },
         {
           "name": "levercoin_auth"
@@ -3111,7 +3262,58 @@
           ]
         },
         {
-          "name": "hylo"
+          "name": "hylo",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  104,
+                  121,
+                  108,
+                  111
+                ]
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                245,
+                187,
+                72,
+                160,
+                4,
+                116,
+                48,
+                134,
+                197,
+                164,
+                152,
+                189,
+                233,
+                219,
+                27,
+                124,
+                201,
+                65,
+                103,
+                243,
+                58,
+                82,
+                140,
+                90,
+                13,
+                150,
+                83,
+                40,
+                223,
+                158,
+                124,
+                33
+              ]
+            }
+          }
         },
         {
           "name": "exo_pair",
@@ -3811,7 +4013,57 @@
         },
         {
           "name": "hylo",
-          "writable": true
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  104,
+                  121,
+                  108,
+                  111
+                ]
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                245,
+                187,
+                72,
+                160,
+                4,
+                116,
+                48,
+                134,
+                197,
+                164,
+                152,
+                189,
+                233,
+                219,
+                27,
+                124,
+                201,
+                65,
+                103,
+                243,
+                58,
+                82,
+                140,
+                90,
+                13,
+                150,
+                83,
+                40,
+                223,
+                158,
+                124,
+                33
+              ]
+            }
+          }
         },
         {
           "name": "sol_usd_pyth_feed"
@@ -3883,7 +4135,57 @@
         },
         {
           "name": "xsol_mint",
-          "writable": true
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  120,
+                  83,
+                  79,
+                  76
+                ]
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                245,
+                187,
+                72,
+                160,
+                4,
+                116,
+                48,
+                134,
+                197,
+                164,
+                152,
+                189,
+                233,
+                219,
+                27,
+                124,
+                201,
+                65,
+                103,
+                243,
+                58,
+                82,
+                140,
+                90,
+                13,
+                150,
+                83,
+                40,
+                223,
+                158,
+                124,
+                33
+              ]
+            }
+          }
         },
         {
           "name": "levercoin_auth"
@@ -4378,6 +4680,11 @@
       "code": 6004,
       "name": "InvalidPythPrice",
       "msg": "Invalid Pyth price update account, feed id, or exponent."
+    },
+    {
+      "code": 6005,
+      "name": "TipArithmetic",
+      "msg": "Executor tip arithmetic overflowed the order's lamport balance."
     }
   ],
   "types": [
@@ -4412,8 +4719,8 @@
       "name": "ConvertDirection",
       "docs": [
         "Direction of the underlying Hylo convert ix the trigger order will fire.",
-        "`StableToLever` burns HYUSD to mint levercoin (the v1 direction).",
-        "`LeverToStable` burns levercoin to mint HYUSD (v1.1 addition)."
+        "`StableToLever` burns HYUSD to mint levercoin; `LeverToStable` burns",
+        "levercoin to mint HYUSD."
       ],
       "type": {
         "kind": "enum",

--- a/hylo-idl/idls/hylo_trigger_orders.json
+++ b/hylo-idl/idls/hylo_trigger_orders.json
@@ -1,0 +1,5528 @@
+{
+  "address": "2GbKbBumaPjHsJ5qzkUt6cnsyTBT6aPNj3gq2mvocpFW",
+  "metadata": {
+    "name": "hylo_trigger_orders",
+    "version": "1.0.0",
+    "spec": "0.1.0",
+    "description": "Hylo Trigger Orders Program"
+  },
+  "instructions": [
+    {
+      "name": "cancel_order_l2s_exo",
+      "discriminator": [
+        61,
+        165,
+        75,
+        198,
+        91,
+        170,
+        235,
+        153
+      ],
+      "accounts": [
+        {
+          "name": "owner",
+          "writable": true,
+          "signer": true,
+          "relations": [
+            "order"
+          ]
+        },
+        {
+          "name": "order",
+          "writable": true
+        },
+        {
+          "name": "order_levercoin_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "order"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "levercoin_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "owner_levercoin_ta",
+          "writable": true
+        },
+        {
+          "name": "levercoin_mint",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  101,
+                  120,
+                  111,
+                  95,
+                  108,
+                  101,
+                  118,
+                  101,
+                  114,
+                  99,
+                  111,
+                  105,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "collateral_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                245,
+                187,
+                72,
+                160,
+                4,
+                116,
+                48,
+                134,
+                197,
+                164,
+                152,
+                189,
+                233,
+                219,
+                27,
+                124,
+                201,
+                65,
+                103,
+                243,
+                58,
+                82,
+                140,
+                90,
+                13,
+                150,
+                83,
+                40,
+                223,
+                158,
+                124,
+                33
+              ]
+            }
+          }
+        },
+        {
+          "name": "collateral_mint",
+          "docs": [
+            "Defines the EXO pair the order targets. Validated against",
+            "`order.pair_target` via the `constraint` on `order` above."
+          ]
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95,
+                  95,
+                  101,
+                  118,
+                  101,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [],
+      "returns": {
+        "defined": {
+          "name": "TriggerOrderCancelled"
+        }
+      }
+    },
+    {
+      "name": "cancel_order_l2s_lst",
+      "discriminator": [
+        121,
+        201,
+        137,
+        113,
+        147,
+        216,
+        109,
+        177
+      ],
+      "accounts": [
+        {
+          "name": "owner",
+          "writable": true,
+          "signer": true,
+          "relations": [
+            "order"
+          ]
+        },
+        {
+          "name": "order",
+          "writable": true
+        },
+        {
+          "name": "order_xsol_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "order"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "xsol_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "owner_xsol_ta",
+          "writable": true
+        },
+        {
+          "name": "xsol_mint",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  120,
+                  83,
+                  79,
+                  76
+                ]
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                245,
+                187,
+                72,
+                160,
+                4,
+                116,
+                48,
+                134,
+                197,
+                164,
+                152,
+                189,
+                233,
+                219,
+                27,
+                124,
+                201,
+                65,
+                103,
+                243,
+                58,
+                82,
+                140,
+                90,
+                13,
+                150,
+                83,
+                40,
+                223,
+                158,
+                124,
+                33
+              ]
+            }
+          }
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95,
+                  95,
+                  101,
+                  118,
+                  101,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [],
+      "returns": {
+        "defined": {
+          "name": "TriggerOrderCancelled"
+        }
+      }
+    },
+    {
+      "name": "cancel_order_s2l",
+      "discriminator": [
+        85,
+        20,
+        75,
+        12,
+        198,
+        159,
+        196,
+        50
+      ],
+      "accounts": [
+        {
+          "name": "owner",
+          "writable": true,
+          "signer": true,
+          "relations": [
+            "order"
+          ]
+        },
+        {
+          "name": "order",
+          "writable": true
+        },
+        {
+          "name": "order_hyusd_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "order"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "hyusd_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "owner_hyusd_ta",
+          "writable": true
+        },
+        {
+          "name": "hyusd_mint",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  104,
+                  121,
+                  85,
+                  83,
+                  68
+                ]
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                245,
+                187,
+                72,
+                160,
+                4,
+                116,
+                48,
+                134,
+                197,
+                164,
+                152,
+                189,
+                233,
+                219,
+                27,
+                124,
+                201,
+                65,
+                103,
+                243,
+                58,
+                82,
+                140,
+                90,
+                13,
+                150,
+                83,
+                40,
+                223,
+                158,
+                124,
+                33
+              ]
+            }
+          }
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95,
+                  95,
+                  101,
+                  118,
+                  101,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [],
+      "returns": {
+        "defined": {
+          "name": "TriggerOrderCancelled"
+        }
+      }
+    },
+    {
+      "name": "create_order_l2s_exo",
+      "discriminator": [
+        145,
+        7,
+        163,
+        2,
+        20,
+        124,
+        128,
+        146
+      ],
+      "accounts": [
+        {
+          "name": "owner",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "order",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111,
+                  114,
+                  100,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "owner"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  1
+                ]
+              },
+              {
+                "kind": "const",
+                "value": [
+                  1
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "collateral_mint"
+              },
+              {
+                "kind": "arg",
+                "path": "nonce"
+              }
+            ]
+          }
+        },
+        {
+          "name": "order_levercoin_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "order"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "levercoin_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "owner_levercoin_ta",
+          "writable": true
+        },
+        {
+          "name": "levercoin_mint",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  101,
+                  120,
+                  111,
+                  95,
+                  108,
+                  101,
+                  118,
+                  101,
+                  114,
+                  99,
+                  111,
+                  105,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "collateral_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                245,
+                187,
+                72,
+                160,
+                4,
+                116,
+                48,
+                134,
+                197,
+                164,
+                152,
+                189,
+                233,
+                219,
+                27,
+                124,
+                201,
+                65,
+                103,
+                243,
+                58,
+                82,
+                140,
+                90,
+                13,
+                150,
+                83,
+                40,
+                223,
+                158,
+                124,
+                33
+              ]
+            }
+          }
+        },
+        {
+          "name": "collateral_mint",
+          "docs": [
+            "Defines the EXO pair the order targets.",
+            "",
+            "Intentionally **not** constrained to a registered `ExoPair`. The obvious",
+            "alternative would be to add a seed-derived `exo_pair: Account<ExoPair>`",
+            "to this struct and let Anchor validate. We don't, because:",
+            "",
+            "- **Cost is real.** Loading `ExoPair` adds one account to the create",
+            "instruction's account list (counts against the 64-account tx ceiling",
+            "shared with the rest of the tx), ~500 bytes of deserialization, and",
+            "commits this program to whatever Hylo's `ExoPair` schema looks like.",
+            "Hylo's `ExoPair` evolves (levercoin caps, fee curves, oracle config",
+            "have all been added over time); each evolution would force a",
+            "trigger-orders upgrade just to keep create working.",
+            "",
+            "- **Benefit is small.** Validation here is UX-only — it catches a",
+            "malformed mint at create instead of at execute. The owner's funds are",
+            "safe either way (see the three guarantees below).",
+            "",
+            "Why we can safely skip the check:",
+            "",
+            "1. The PDA seeds bind this mint cryptographically (see the `order` seeds",
+            "above), so a malformed mint creates a PDA at an address unique to that",
+            "owner/nonce/mint triple. No collision risk with other orders.",
+            "2. Only the owner is harmed by an unfillable order — their levercoin goes",
+            "into a PDA they alone can drain via `cancel_order_l2s_exo`. There's no",
+            "path for an attacker to lock anyone else's funds via this vector.",
+            "3. The cancel path doesn't read `ExoPair`, `Hylo`, or any pair-specific",
+            "state. So even if Hylo deprecates this collateral, the owner can",
+            "always recover. Funds-recoverability is structural, not policy.",
+            "",
+            "At execute time, the keeper passes the actual `ExoPair` account; it's",
+            "constrained to derive from this `collateral_mint`, so wrong-pair",
+            "execution attempts revert at account loading before any token movement."
+          ]
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "associated_token_program",
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "rent",
+          "address": "SysvarRent111111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95,
+                  95,
+                  101,
+                  118,
+                  101,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "nonce",
+          "type": "u64"
+        },
+        {
+          "name": "escrow_amount",
+          "type": "u64"
+        },
+        {
+          "name": "trigger_price",
+          "type": "i64"
+        },
+        {
+          "name": "trigger_expo",
+          "type": "i32"
+        },
+        {
+          "name": "direction",
+          "type": {
+            "defined": {
+              "name": "TriggerDirection"
+            }
+          }
+        }
+      ],
+      "returns": {
+        "defined": {
+          "name": "TriggerOrderCreated"
+        }
+      }
+    },
+    {
+      "name": "create_order_l2s_lst",
+      "discriminator": [
+        217,
+        157,
+        106,
+        121,
+        230,
+        232,
+        238,
+        73
+      ],
+      "accounts": [
+        {
+          "name": "owner",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "order",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111,
+                  114,
+                  100,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "owner"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  1
+                ]
+              },
+              {
+                "kind": "const",
+                "value": [
+                  0
+                ]
+              },
+              {
+                "kind": "arg",
+                "path": "nonce"
+              }
+            ]
+          }
+        },
+        {
+          "name": "order_xsol_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "order"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "xsol_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "owner_xsol_ta",
+          "writable": true
+        },
+        {
+          "name": "xsol_mint",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  120,
+                  83,
+                  79,
+                  76
+                ]
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                245,
+                187,
+                72,
+                160,
+                4,
+                116,
+                48,
+                134,
+                197,
+                164,
+                152,
+                189,
+                233,
+                219,
+                27,
+                124,
+                201,
+                65,
+                103,
+                243,
+                58,
+                82,
+                140,
+                90,
+                13,
+                150,
+                83,
+                40,
+                223,
+                158,
+                124,
+                33
+              ]
+            }
+          }
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "associated_token_program",
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "rent",
+          "address": "SysvarRent111111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95,
+                  95,
+                  101,
+                  118,
+                  101,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "nonce",
+          "type": "u64"
+        },
+        {
+          "name": "escrow_amount",
+          "type": "u64"
+        },
+        {
+          "name": "trigger_price",
+          "type": "i64"
+        },
+        {
+          "name": "trigger_expo",
+          "type": "i32"
+        },
+        {
+          "name": "direction",
+          "type": {
+            "defined": {
+              "name": "TriggerDirection"
+            }
+          }
+        }
+      ],
+      "returns": {
+        "defined": {
+          "name": "TriggerOrderCreated"
+        }
+      }
+    },
+    {
+      "name": "create_order_s2l_exo",
+      "discriminator": [
+        102,
+        197,
+        120,
+        21,
+        57,
+        139,
+        195,
+        202
+      ],
+      "accounts": [
+        {
+          "name": "owner",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "order",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111,
+                  114,
+                  100,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "owner"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  0
+                ]
+              },
+              {
+                "kind": "const",
+                "value": [
+                  1
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "collateral_mint"
+              },
+              {
+                "kind": "arg",
+                "path": "nonce"
+              }
+            ]
+          }
+        },
+        {
+          "name": "order_hyusd_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "order"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "hyusd_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "owner_hyusd_ta",
+          "writable": true
+        },
+        {
+          "name": "hyusd_mint",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  104,
+                  121,
+                  85,
+                  83,
+                  68
+                ]
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                245,
+                187,
+                72,
+                160,
+                4,
+                116,
+                48,
+                134,
+                197,
+                164,
+                152,
+                189,
+                233,
+                219,
+                27,
+                124,
+                201,
+                65,
+                103,
+                243,
+                58,
+                82,
+                140,
+                90,
+                13,
+                150,
+                83,
+                40,
+                223,
+                158,
+                124,
+                33
+              ]
+            }
+          }
+        },
+        {
+          "name": "collateral_mint",
+          "docs": [
+            "Defines the EXO pair the order targets.",
+            "",
+            "Intentionally **not** constrained to a registered `ExoPair`. The obvious",
+            "alternative would be to add a seed-derived `exo_pair: Account<ExoPair>`",
+            "to this struct and let Anchor validate. We don't, because:",
+            "",
+            "- **Cost is real.** Loading `ExoPair` adds one account to the create",
+            "instruction's account list (counts against the 64-account tx ceiling",
+            "shared with the rest of the tx), ~500 bytes of deserialization, and",
+            "commits this program to whatever Hylo's `ExoPair` schema looks like.",
+            "Hylo's `ExoPair` evolves (levercoin caps, fee curves, oracle config",
+            "have all been added over time); each evolution would force a",
+            "trigger-orders upgrade just to keep create working.",
+            "",
+            "- **Benefit is small.** Validation here is UX-only — it catches a",
+            "malformed mint at create instead of at execute. The owner's funds are",
+            "safe either way (see the three guarantees below).",
+            "",
+            "Why we can safely skip the check:",
+            "",
+            "1. The PDA seeds bind this mint cryptographically (see the `order` seeds",
+            "above), so a malformed mint creates a PDA at an address unique to that",
+            "owner/nonce/mint triple. No collision risk with other orders.",
+            "2. Only the owner is harmed by an unfillable order — their HYUSD goes",
+            "into a PDA they alone can drain via `cancel_order_s2l`. There's no",
+            "path for an attacker to lock anyone else's funds via this vector.",
+            "3. The cancel path doesn't read `ExoPair`, `Hylo`, or any pair-specific",
+            "state. So even if Hylo deprecates this collateral, the owner can",
+            "always recover. Funds-recoverability is structural, not policy.",
+            "",
+            "At execute time, the keeper passes the actual `ExoPair` account; it's",
+            "constrained to derive from this `collateral_mint`, so wrong-pair",
+            "execution attempts revert at account loading before any token movement."
+          ]
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "associated_token_program",
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "rent",
+          "address": "SysvarRent111111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95,
+                  95,
+                  101,
+                  118,
+                  101,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "nonce",
+          "type": "u64"
+        },
+        {
+          "name": "escrow_amount",
+          "type": "u64"
+        },
+        {
+          "name": "trigger_price",
+          "type": "i64"
+        },
+        {
+          "name": "trigger_expo",
+          "type": "i32"
+        },
+        {
+          "name": "direction",
+          "type": {
+            "defined": {
+              "name": "TriggerDirection"
+            }
+          }
+        }
+      ],
+      "returns": {
+        "defined": {
+          "name": "TriggerOrderCreated"
+        }
+      }
+    },
+    {
+      "name": "create_order_s2l_lst",
+      "discriminator": [
+        1,
+        195,
+        39,
+        158,
+        147,
+        192,
+        10,
+        101
+      ],
+      "accounts": [
+        {
+          "name": "owner",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "order",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111,
+                  114,
+                  100,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "owner"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  0
+                ]
+              },
+              {
+                "kind": "const",
+                "value": [
+                  0
+                ]
+              },
+              {
+                "kind": "arg",
+                "path": "nonce"
+              }
+            ]
+          }
+        },
+        {
+          "name": "order_hyusd_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "order"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "hyusd_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "owner_hyusd_ta",
+          "writable": true
+        },
+        {
+          "name": "hyusd_mint",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  104,
+                  121,
+                  85,
+                  83,
+                  68
+                ]
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                245,
+                187,
+                72,
+                160,
+                4,
+                116,
+                48,
+                134,
+                197,
+                164,
+                152,
+                189,
+                233,
+                219,
+                27,
+                124,
+                201,
+                65,
+                103,
+                243,
+                58,
+                82,
+                140,
+                90,
+                13,
+                150,
+                83,
+                40,
+                223,
+                158,
+                124,
+                33
+              ]
+            }
+          }
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "associated_token_program",
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "rent",
+          "address": "SysvarRent111111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95,
+                  95,
+                  101,
+                  118,
+                  101,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "nonce",
+          "type": "u64"
+        },
+        {
+          "name": "escrow_amount",
+          "type": "u64"
+        },
+        {
+          "name": "trigger_price",
+          "type": "i64"
+        },
+        {
+          "name": "trigger_expo",
+          "type": "i32"
+        },
+        {
+          "name": "direction",
+          "type": {
+            "defined": {
+              "name": "TriggerDirection"
+            }
+          }
+        }
+      ],
+      "returns": {
+        "defined": {
+          "name": "TriggerOrderCreated"
+        }
+      }
+    },
+    {
+      "name": "execute_order_l2s_exo",
+      "discriminator": [
+        112,
+        175,
+        205,
+        216,
+        129,
+        95,
+        184,
+        153
+      ],
+      "accounts": [
+        {
+          "name": "executor",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "owner",
+          "writable": true,
+          "relations": [
+            "order"
+          ]
+        },
+        {
+          "name": "hylo"
+        },
+        {
+          "name": "exo_pair",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  101,
+                  120,
+                  111,
+                  95,
+                  112,
+                  97,
+                  105,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "collateral_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                245,
+                187,
+                72,
+                160,
+                4,
+                116,
+                48,
+                134,
+                197,
+                164,
+                152,
+                189,
+                233,
+                219,
+                27,
+                124,
+                201,
+                65,
+                103,
+                243,
+                58,
+                82,
+                140,
+                90,
+                13,
+                150,
+                83,
+                40,
+                223,
+                158,
+                124,
+                33
+              ]
+            }
+          }
+        },
+        {
+          "name": "collateral_mint",
+          "relations": [
+            "exo_pair"
+          ]
+        },
+        {
+          "name": "vault_auth"
+        },
+        {
+          "name": "collateral_vault",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "vault_auth"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "collateral_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "collateral_usd_pyth_feed"
+        },
+        {
+          "name": "hyusd_mint",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  104,
+                  121,
+                  85,
+                  83,
+                  68
+                ]
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                245,
+                187,
+                72,
+                160,
+                4,
+                116,
+                48,
+                134,
+                197,
+                164,
+                152,
+                189,
+                233,
+                219,
+                27,
+                124,
+                201,
+                65,
+                103,
+                243,
+                58,
+                82,
+                140,
+                90,
+                13,
+                150,
+                83,
+                40,
+                223,
+                158,
+                124,
+                33
+              ]
+            }
+          }
+        },
+        {
+          "name": "stablecoin_auth"
+        },
+        {
+          "name": "fee_auth"
+        },
+        {
+          "name": "fee_vault",
+          "writable": true
+        },
+        {
+          "name": "levercoin_mint",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  101,
+                  120,
+                  111,
+                  95,
+                  108,
+                  101,
+                  118,
+                  101,
+                  114,
+                  99,
+                  111,
+                  105,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "collateral_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                245,
+                187,
+                72,
+                160,
+                4,
+                116,
+                48,
+                134,
+                197,
+                164,
+                152,
+                189,
+                233,
+                219,
+                27,
+                124,
+                201,
+                65,
+                103,
+                243,
+                58,
+                82,
+                140,
+                90,
+                13,
+                150,
+                83,
+                40,
+                223,
+                158,
+                124,
+                33
+              ]
+            }
+          }
+        },
+        {
+          "name": "levercoin_auth"
+        },
+        {
+          "name": "order",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111,
+                  114,
+                  100,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "order.owner",
+                "account": "TriggerOrder"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  1
+                ]
+              },
+              {
+                "kind": "const",
+                "value": [
+                  1
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "collateral_mint"
+              },
+              {
+                "kind": "account",
+                "path": "order.nonce",
+                "account": "TriggerOrder"
+              }
+            ]
+          }
+        },
+        {
+          "name": "order_levercoin_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "order"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "levercoin_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "order_hyusd_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "order"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "hyusd_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "owner_hyusd_ta",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "owner"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "hyusd_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "hylo_exchange_event_authority"
+        },
+        {
+          "name": "hylo_exchange_program",
+          "address": "HYEXCHtHkBagdStcJCp3xbbb9B7sdMdWXFNj6mdsG4hn"
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "associated_token_program",
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95,
+                  95,
+                  101,
+                  118,
+                  101,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [],
+      "returns": {
+        "defined": {
+          "name": "TriggerOrderFilled"
+        }
+      }
+    },
+    {
+      "name": "execute_order_l2s_lst",
+      "discriminator": [
+        96,
+        37,
+        224,
+        31,
+        190,
+        139,
+        223,
+        0
+      ],
+      "accounts": [
+        {
+          "name": "executor",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "owner",
+          "writable": true,
+          "relations": [
+            "order"
+          ]
+        },
+        {
+          "name": "hylo",
+          "writable": true
+        },
+        {
+          "name": "sol_usd_pyth_feed"
+        },
+        {
+          "name": "hyusd_mint",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  104,
+                  121,
+                  85,
+                  83,
+                  68
+                ]
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                245,
+                187,
+                72,
+                160,
+                4,
+                116,
+                48,
+                134,
+                197,
+                164,
+                152,
+                189,
+                233,
+                219,
+                27,
+                124,
+                201,
+                65,
+                103,
+                243,
+                58,
+                82,
+                140,
+                90,
+                13,
+                150,
+                83,
+                40,
+                223,
+                158,
+                124,
+                33
+              ]
+            }
+          }
+        },
+        {
+          "name": "stablecoin_auth"
+        },
+        {
+          "name": "fee_auth"
+        },
+        {
+          "name": "fee_vault",
+          "writable": true
+        },
+        {
+          "name": "xsol_mint",
+          "writable": true
+        },
+        {
+          "name": "levercoin_auth"
+        },
+        {
+          "name": "order",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111,
+                  114,
+                  100,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "order.owner",
+                "account": "TriggerOrder"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  1
+                ]
+              },
+              {
+                "kind": "const",
+                "value": [
+                  0
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "order.nonce",
+                "account": "TriggerOrder"
+              }
+            ]
+          }
+        },
+        {
+          "name": "order_xsol_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "order"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "xsol_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "order_hyusd_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "order"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "hyusd_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "owner_hyusd_ta",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "owner"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "hyusd_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "hylo_exchange_event_authority"
+        },
+        {
+          "name": "hylo_exchange_program",
+          "address": "HYEXCHtHkBagdStcJCp3xbbb9B7sdMdWXFNj6mdsG4hn"
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "associated_token_program",
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95,
+                  95,
+                  101,
+                  118,
+                  101,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [],
+      "returns": {
+        "defined": {
+          "name": "TriggerOrderFilled"
+        }
+      }
+    },
+    {
+      "name": "execute_order_s2l_exo",
+      "discriminator": [
+        29,
+        184,
+        147,
+        164,
+        106,
+        9,
+        121,
+        21
+      ],
+      "accounts": [
+        {
+          "name": "executor",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "owner",
+          "writable": true,
+          "relations": [
+            "order"
+          ]
+        },
+        {
+          "name": "hylo"
+        },
+        {
+          "name": "exo_pair",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  101,
+                  120,
+                  111,
+                  95,
+                  112,
+                  97,
+                  105,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "collateral_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                245,
+                187,
+                72,
+                160,
+                4,
+                116,
+                48,
+                134,
+                197,
+                164,
+                152,
+                189,
+                233,
+                219,
+                27,
+                124,
+                201,
+                65,
+                103,
+                243,
+                58,
+                82,
+                140,
+                90,
+                13,
+                150,
+                83,
+                40,
+                223,
+                158,
+                124,
+                33
+              ]
+            }
+          }
+        },
+        {
+          "name": "collateral_mint",
+          "relations": [
+            "exo_pair"
+          ]
+        },
+        {
+          "name": "vault_auth"
+        },
+        {
+          "name": "collateral_vault",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "vault_auth"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "collateral_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "collateral_usd_pyth_feed"
+        },
+        {
+          "name": "hyusd_mint",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  104,
+                  121,
+                  85,
+                  83,
+                  68
+                ]
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                245,
+                187,
+                72,
+                160,
+                4,
+                116,
+                48,
+                134,
+                197,
+                164,
+                152,
+                189,
+                233,
+                219,
+                27,
+                124,
+                201,
+                65,
+                103,
+                243,
+                58,
+                82,
+                140,
+                90,
+                13,
+                150,
+                83,
+                40,
+                223,
+                158,
+                124,
+                33
+              ]
+            }
+          }
+        },
+        {
+          "name": "stablecoin_auth"
+        },
+        {
+          "name": "fee_auth"
+        },
+        {
+          "name": "fee_vault",
+          "writable": true
+        },
+        {
+          "name": "levercoin_mint",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  101,
+                  120,
+                  111,
+                  95,
+                  108,
+                  101,
+                  118,
+                  101,
+                  114,
+                  99,
+                  111,
+                  105,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "collateral_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                245,
+                187,
+                72,
+                160,
+                4,
+                116,
+                48,
+                134,
+                197,
+                164,
+                152,
+                189,
+                233,
+                219,
+                27,
+                124,
+                201,
+                65,
+                103,
+                243,
+                58,
+                82,
+                140,
+                90,
+                13,
+                150,
+                83,
+                40,
+                223,
+                158,
+                124,
+                33
+              ]
+            }
+          }
+        },
+        {
+          "name": "levercoin_auth"
+        },
+        {
+          "name": "order",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111,
+                  114,
+                  100,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "order.owner",
+                "account": "TriggerOrder"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  0
+                ]
+              },
+              {
+                "kind": "const",
+                "value": [
+                  1
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "collateral_mint"
+              },
+              {
+                "kind": "account",
+                "path": "order.nonce",
+                "account": "TriggerOrder"
+              }
+            ]
+          }
+        },
+        {
+          "name": "order_hyusd_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "order"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "hyusd_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "order_levercoin_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "order"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "levercoin_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "owner_levercoin_ta",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "owner"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "levercoin_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "hylo_exchange_event_authority"
+        },
+        {
+          "name": "hylo_exchange_program",
+          "address": "HYEXCHtHkBagdStcJCp3xbbb9B7sdMdWXFNj6mdsG4hn"
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "associated_token_program",
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95,
+                  95,
+                  101,
+                  118,
+                  101,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [],
+      "returns": {
+        "defined": {
+          "name": "TriggerOrderFilled"
+        }
+      }
+    },
+    {
+      "name": "execute_order_s2l_lst",
+      "discriminator": [
+        26,
+        104,
+        100,
+        203,
+        82,
+        5,
+        112,
+        58
+      ],
+      "accounts": [
+        {
+          "name": "executor",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "owner",
+          "writable": true,
+          "relations": [
+            "order"
+          ]
+        },
+        {
+          "name": "hylo",
+          "writable": true
+        },
+        {
+          "name": "sol_usd_pyth_feed"
+        },
+        {
+          "name": "hyusd_mint",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  104,
+                  121,
+                  85,
+                  83,
+                  68
+                ]
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                245,
+                187,
+                72,
+                160,
+                4,
+                116,
+                48,
+                134,
+                197,
+                164,
+                152,
+                189,
+                233,
+                219,
+                27,
+                124,
+                201,
+                65,
+                103,
+                243,
+                58,
+                82,
+                140,
+                90,
+                13,
+                150,
+                83,
+                40,
+                223,
+                158,
+                124,
+                33
+              ]
+            }
+          }
+        },
+        {
+          "name": "stablecoin_auth"
+        },
+        {
+          "name": "fee_auth"
+        },
+        {
+          "name": "fee_vault",
+          "writable": true
+        },
+        {
+          "name": "xsol_mint",
+          "writable": true
+        },
+        {
+          "name": "levercoin_auth"
+        },
+        {
+          "name": "order",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111,
+                  114,
+                  100,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "order.owner",
+                "account": "TriggerOrder"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  0
+                ]
+              },
+              {
+                "kind": "const",
+                "value": [
+                  0
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "order.nonce",
+                "account": "TriggerOrder"
+              }
+            ]
+          }
+        },
+        {
+          "name": "order_hyusd_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "order"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "hyusd_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "order_xsol_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "order"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "xsol_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "owner_xsol_ta",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "owner"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "xsol_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "hylo_exchange_event_authority"
+        },
+        {
+          "name": "hylo_exchange_program",
+          "address": "HYEXCHtHkBagdStcJCp3xbbb9B7sdMdWXFNj6mdsG4hn"
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "associated_token_program",
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95,
+                  95,
+                  101,
+                  118,
+                  101,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [],
+      "returns": {
+        "defined": {
+          "name": "TriggerOrderFilled"
+        }
+      }
+    }
+  ],
+  "accounts": [
+    {
+      "name": "ExoPair",
+      "discriminator": [
+        251,
+        244,
+        72,
+        181,
+        40,
+        119,
+        232,
+        48
+      ]
+    },
+    {
+      "name": "Hylo",
+      "discriminator": [
+        114,
+        161,
+        169,
+        210,
+        204,
+        175,
+        149,
+        174
+      ]
+    },
+    {
+      "name": "PriceUpdateV2",
+      "discriminator": [
+        34,
+        241,
+        35,
+        99,
+        157,
+        126,
+        244,
+        205
+      ]
+    },
+    {
+      "name": "TriggerOrder",
+      "discriminator": [
+        236,
+        61,
+        42,
+        190,
+        152,
+        12,
+        106,
+        116
+      ]
+    }
+  ],
+  "events": [
+    {
+      "name": "TriggerOrderCancelled",
+      "discriminator": [
+        255,
+        151,
+        206,
+        140,
+        98,
+        153,
+        223,
+        121
+      ]
+    },
+    {
+      "name": "TriggerOrderCreated",
+      "discriminator": [
+        90,
+        78,
+        39,
+        34,
+        130,
+        168,
+        79,
+        55
+      ]
+    },
+    {
+      "name": "TriggerOrderFilled",
+      "discriminator": [
+        124,
+        156,
+        201,
+        86,
+        158,
+        86,
+        183,
+        212
+      ]
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "AmountTooSmall",
+      "msg": "escrow_amount must be > 0"
+    },
+    {
+      "code": 6001,
+      "name": "AccountMismatch",
+      "msg": "account does not match the order's pair target"
+    },
+    {
+      "code": 6002,
+      "name": "TriggerNotMet",
+      "msg": "price condition not met"
+    },
+    {
+      "code": 6003,
+      "name": "Unauthorized",
+      "msg": "signer is not the order owner"
+    },
+    {
+      "code": 6004,
+      "name": "InvalidPythPrice",
+      "msg": "invalid pyth price update account, feed id, or expo"
+    }
+  ],
+  "types": [
+    {
+      "name": "BorrowRateConfig",
+      "docs": [
+        "Per-epoch borrow rate for exogenous collateral without native yield."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "rate",
+            "type": {
+              "defined": {
+                "name": "UFixValue64"
+              }
+            }
+          },
+          {
+            "name": "fee",
+            "type": {
+              "defined": {
+                "name": "UFixValue64"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ConvertDirection",
+      "docs": [
+        "Direction of the underlying Hylo convert ix the trigger order will fire.",
+        "`StableToLever` burns HYUSD to mint levercoin (the v1 direction).",
+        "`LeverToStable` burns levercoin to mint HYUSD (v1.1 addition)."
+      ],
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "StableToLever"
+          },
+          {
+            "name": "LeverToStable"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ExoPair",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "collateral_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "levercoin_mint_bump",
+            "type": "u8"
+          },
+          {
+            "name": "levercoin_auth_bump",
+            "type": "u8"
+          },
+          {
+            "name": "vault_auth_bump",
+            "type": "u8"
+          },
+          {
+            "name": "fee_auth_bump",
+            "type": "u8"
+          },
+          {
+            "name": "oracle",
+            "type": "pubkey"
+          },
+          {
+            "name": "oracle_feed_id",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "oracle_interval_secs",
+            "type": "u64"
+          },
+          {
+            "name": "oracle_conf_tolerance",
+            "type": {
+              "defined": {
+                "name": "UFixValue64"
+              }
+            }
+          },
+          {
+            "name": "stablecoin_mint_threshold",
+            "type": {
+              "defined": {
+                "name": "UFixValue64"
+              }
+            }
+          },
+          {
+            "name": "virtual_stablecoin",
+            "type": {
+              "defined": {
+                "name": "VirtualStablecoin"
+              }
+            }
+          },
+          {
+            "name": "borrow_rate_config",
+            "type": {
+              "defined": {
+                "name": "BorrowRateConfig"
+              }
+            }
+          },
+          {
+            "name": "borrow_rate_harvest_cache",
+            "type": {
+              "defined": {
+                "name": "HarvestCache"
+              }
+            }
+          },
+          {
+            "name": "levercoin_fees",
+            "type": {
+              "defined": {
+                "name": "LevercoinFees"
+              }
+            }
+          },
+          {
+            "name": "sell_curve_config",
+            "type": {
+              "defined": {
+                "name": "RebalanceCurveConfig"
+              }
+            }
+          },
+          {
+            "name": "buy_curve_config",
+            "type": {
+              "defined": {
+                "name": "RebalanceCurveConfig"
+              }
+            }
+          },
+          {
+            "name": "rebalance_deviation_tolerance",
+            "type": {
+              "defined": {
+                "name": "UFixValue64"
+              }
+            }
+          },
+          {
+            "name": "paused",
+            "type": "bool"
+          },
+          {
+            "name": "levercoin_market_cap_limit",
+            "type": {
+              "defined": {
+                "name": "UFixValue64"
+              }
+            }
+          },
+          {
+            "name": "pool_drawdown",
+            "type": {
+              "defined": {
+                "name": "PoolDrawdown"
+              }
+            }
+          },
+          {
+            "name": "_reserved",
+            "type": {
+              "array": [
+                "u8",
+                100
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "FeePair",
+      "docs": [
+        "Represents the spread of fees between mint and redeem for protocol tokens.",
+        "All fees must be in basis points to represent a fractional percentage",
+        "directly applicable to a token amount e.g. `0.XXXX` or `bips x 10^-4`."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "mint",
+            "type": {
+              "defined": {
+                "name": "UFixValue64"
+              }
+            }
+          },
+          {
+            "name": "redeem",
+            "type": {
+              "defined": {
+                "name": "UFixValue64"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "HarvestCache",
+      "docs": [
+        "Records epoch harvest information for off-chain consumers."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "epoch",
+            "type": "u64"
+          },
+          {
+            "name": "stability_pool_cap",
+            "type": {
+              "defined": {
+                "name": "UFixValue64"
+              }
+            }
+          },
+          {
+            "name": "stablecoin_to_pool",
+            "type": {
+              "defined": {
+                "name": "UFixValue64"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Hylo",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "admin",
+            "type": "pubkey"
+          },
+          {
+            "name": "treasury",
+            "type": "pubkey"
+          },
+          {
+            "name": "lst_registry",
+            "type": "pubkey"
+          },
+          {
+            "name": "stablecoin_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "levercoin_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "pause_authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "stablecoin_mint_bump",
+            "type": "u8"
+          },
+          {
+            "name": "stablecoin_auth_bump",
+            "type": "u8"
+          },
+          {
+            "name": "levercoin_mint_bump",
+            "type": "u8"
+          },
+          {
+            "name": "levercoin_auth_bump",
+            "type": "u8"
+          },
+          {
+            "name": "registry_auth_bump",
+            "type": "u8"
+          },
+          {
+            "name": "total_sol_cache_bump",
+            "type": "u8"
+          },
+          {
+            "name": "oracle_interval_secs",
+            "type": "u64"
+          },
+          {
+            "name": "stablecoin_fees",
+            "type": {
+              "defined": {
+                "name": "StablecoinFees"
+              }
+            }
+          },
+          {
+            "name": "levercoin_fees",
+            "type": {
+              "defined": {
+                "name": "LevercoinFees"
+              }
+            }
+          },
+          {
+            "name": "total_sol_cache",
+            "type": {
+              "defined": {
+                "name": "TotalSolCache"
+              }
+            }
+          },
+          {
+            "name": "yield_harvest_cache",
+            "type": {
+              "defined": {
+                "name": "HarvestCache"
+              }
+            }
+          },
+          {
+            "name": "yield_harvest_config",
+            "type": {
+              "defined": {
+                "name": "YieldHarvestConfig"
+              }
+            }
+          },
+          {
+            "name": "stablecoin_mint_threshold",
+            "type": {
+              "defined": {
+                "name": "UFixValue64"
+              }
+            }
+          },
+          {
+            "name": "_legacy_stability_threshold_2",
+            "type": {
+              "defined": {
+                "name": "UFixValue64"
+              }
+            }
+          },
+          {
+            "name": "oracle_conf_tolerance",
+            "type": {
+              "defined": {
+                "name": "UFixValue64"
+              }
+            }
+          },
+          {
+            "name": "sol_usd_oracle",
+            "type": "pubkey"
+          },
+          {
+            "name": "lst_swap_fee",
+            "type": {
+              "defined": {
+                "name": "UFixValue64"
+              }
+            }
+          },
+          {
+            "name": "virtual_stablecoin",
+            "type": {
+              "defined": {
+                "name": "VirtualStablecoin"
+              }
+            }
+          },
+          {
+            "name": "lst_buy_curve_config",
+            "type": {
+              "defined": {
+                "name": "RebalanceCurveConfig"
+              }
+            }
+          },
+          {
+            "name": "lst_sell_curve_config",
+            "type": {
+              "defined": {
+                "name": "RebalanceCurveConfig"
+              }
+            }
+          },
+          {
+            "name": "protocol_paused",
+            "type": "bool"
+          },
+          {
+            "name": "lst_pair_paused",
+            "type": "bool"
+          },
+          {
+            "name": "rebalance_deviation_tolerance",
+            "type": {
+              "defined": {
+                "name": "UFixValue64"
+              }
+            }
+          },
+          {
+            "name": "pool_drawdown",
+            "type": {
+              "defined": {
+                "name": "PoolDrawdown"
+              }
+            }
+          },
+          {
+            "name": "_reserved",
+            "type": {
+              "array": [
+                "u8",
+                13
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "LevercoinFees",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "normal",
+            "type": {
+              "defined": {
+                "name": "FeePair"
+              }
+            }
+          },
+          {
+            "name": "sell_zone_1",
+            "type": {
+              "defined": {
+                "name": "FeePair"
+              }
+            }
+          },
+          {
+            "name": "sell_zone_2",
+            "type": {
+              "defined": {
+                "name": "FeePair"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PairTarget",
+      "docs": [
+        "Which Hylo pair an order targets: an LST pair (output xSOL) or an EXO",
+        "pair (output the per-collateral xASSET)."
+      ],
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Lst"
+          },
+          {
+            "name": "Exo",
+            "fields": [
+              {
+                "name": "collateral_mint",
+                "type": "pubkey"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "PoolDrawdown",
+      "docs": [
+        "Outstanding hyUSD debt owed to the earn pool after a Depeg absorption."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "ledger",
+            "type": {
+              "defined": {
+                "name": "VirtualStablecoin"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PriceFeedMessage",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "feed_id",
+            "docs": [
+              "`FeedId` but avoid the type alias because of compatibility issues with Anchor's `idl-build` feature."
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "price",
+            "type": "i64"
+          },
+          {
+            "name": "conf",
+            "type": "u64"
+          },
+          {
+            "name": "exponent",
+            "type": "i32"
+          },
+          {
+            "name": "publish_time",
+            "docs": [
+              "The timestamp of this price update in seconds"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "prev_publish_time",
+            "docs": [
+              "The timestamp of the previous price update. This field is intended to allow users to",
+              "identify the single unique price update for any moment in time:",
+              "for any time t, the unique update is the one such that prev_publish_time < t <= publish_time.",
+              "",
+              "Note that there may not be such an update while we are migrating to the new message-sending logic,",
+              "as some price updates on pythnet may not be sent to other chains (because the message-sending",
+              "logic may not have triggered). We can solve this problem by making the message-sending mandatory",
+              "(which we can do once publishers have migrated over).",
+              "",
+              "Additionally, this field may be equal to publish_time if the message is sent on a slot where",
+              "where the aggregation was unsuccesful. This problem will go away once all publishers have",
+              "migrated over to a recent version of pyth-agent."
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "ema_price",
+            "type": "i64"
+          },
+          {
+            "name": "ema_conf",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PriceUpdateV2",
+      "docs": [
+        "A price update account. This account is used by the Pyth Receiver program to store a verified price update from a Pyth price feed.",
+        "It contains:",
+        "- `write_authority`: The write authority for this account. This authority can close this account to reclaim rent or update the account to contain a different price update.",
+        "- `verification_level`: The [`VerificationLevel`] of this price update. This represents how many Wormhole guardian signatures have been verified for this price update.",
+        "- `price_message`: The actual price update.",
+        "- `posted_slot`: The slot at which this price update was posted."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "write_authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "verification_level",
+            "type": {
+              "defined": {
+                "name": "VerificationLevel"
+              }
+            }
+          },
+          {
+            "name": "price_message",
+            "type": {
+              "defined": {
+                "name": "PriceFeedMessage"
+              }
+            }
+          },
+          {
+            "name": "posted_slot",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RebalanceCurveConfig",
+      "docs": [
+        "Confidence interval multipliers for rebalance price curve construction."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "floor_mult",
+            "type": {
+              "defined": {
+                "name": "UFixValue64"
+              }
+            }
+          },
+          {
+            "name": "ceil_mult",
+            "type": {
+              "defined": {
+                "name": "UFixValue64"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "StablecoinFees",
+      "docs": [
+        "**Deprecated** — retained only for `Hylo` account deserialization."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "normal",
+            "type": {
+              "defined": {
+                "name": "FeePair"
+              }
+            }
+          },
+          {
+            "name": "mode_1",
+            "type": {
+              "defined": {
+                "name": "FeePair"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "TotalSolCache",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "current_update_epoch",
+            "type": "u64"
+          },
+          {
+            "name": "total_sol",
+            "type": {
+              "defined": {
+                "name": "UFixValue64"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "TriggerDirection",
+      "docs": [
+        "Direction of a trigger order: fill when the underlying price is at or",
+        "below the trigger, or at or above."
+      ],
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "AtOrBelow"
+          },
+          {
+            "name": "AtOrAbove"
+          }
+        ]
+      }
+    },
+    {
+      "name": "TriggerOrder",
+      "docs": [
+        "Per-order escrow account holding the user's escrow + trigger parameters."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "owner",
+            "docs": [
+              "Owner can cancel; receives output on fill."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "pair_target",
+            "type": {
+              "defined": {
+                "name": "PairTarget"
+              }
+            }
+          },
+          {
+            "name": "convert_direction",
+            "docs": [
+              "Direction of the Hylo convert ix this order will fire (s2l or l2s)."
+            ],
+            "type": {
+              "defined": {
+                "name": "ConvertDirection"
+              }
+            }
+          },
+          {
+            "name": "nonce",
+            "docs": [
+              "Client-chosen; `(owner, convert_direction, pair_target, nonce)` is",
+              "unique."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "escrow_amount",
+            "docs": [
+              "Amount escrowed in the order's escrow vault. Unit depends on",
+              "`convert_direction`: HYUSD for s2l; xSOL or per-EXO levercoin for l2s."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "trigger_price",
+            "docs": [
+              "Pyth-style price."
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "trigger_expo",
+            "docs": [
+              "Pyth-style exponent."
+            ],
+            "type": "i32"
+          },
+          {
+            "name": "direction",
+            "type": {
+              "defined": {
+                "name": "TriggerDirection"
+              }
+            }
+          },
+          {
+            "name": "created_at",
+            "docs": [
+              "Unix timestamp from Anchor's `Clock` at create."
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "TriggerOrderCancelled",
+      "docs": [
+        "Emitted at the end of `cancel_order_{s2l,l2s_lst,l2s_exo}` after the",
+        "refund completes."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "order",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "pair_target",
+            "type": {
+              "defined": {
+                "name": "PairTarget"
+              }
+            }
+          },
+          {
+            "name": "convert_direction",
+            "type": {
+              "defined": {
+                "name": "ConvertDirection"
+              }
+            }
+          },
+          {
+            "name": "nonce",
+            "type": "u64"
+          },
+          {
+            "name": "escrow_refunded",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "TriggerOrderCreated",
+      "docs": [
+        "Emitted at the end of `create_order_{s2l,l2s}_{lst,exo}` after state",
+        "mutations succeed."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "order",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "pair_target",
+            "type": {
+              "defined": {
+                "name": "PairTarget"
+              }
+            }
+          },
+          {
+            "name": "convert_direction",
+            "type": {
+              "defined": {
+                "name": "ConvertDirection"
+              }
+            }
+          },
+          {
+            "name": "nonce",
+            "type": "u64"
+          },
+          {
+            "name": "escrow_amount",
+            "docs": [
+              "Amount escrowed (HYUSD for s2l, levercoin for l2s)."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "trigger_price",
+            "type": "i64"
+          },
+          {
+            "name": "trigger_expo",
+            "type": "i32"
+          },
+          {
+            "name": "direction",
+            "type": {
+              "defined": {
+                "name": "TriggerDirection"
+              }
+            }
+          },
+          {
+            "name": "created_at",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "TriggerOrderFilled",
+      "docs": [
+        "Emitted at the end of `execute_order_{s2l,l2s}_{lst,exo}` after the order",
+        "fills. `output_received` mirrors Hylo's convert event field",
+        "(`UFixValue64`) verbatim."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "order",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "executor",
+            "type": "pubkey"
+          },
+          {
+            "name": "pair_target",
+            "type": {
+              "defined": {
+                "name": "PairTarget"
+              }
+            }
+          },
+          {
+            "name": "convert_direction",
+            "type": {
+              "defined": {
+                "name": "ConvertDirection"
+              }
+            }
+          },
+          {
+            "name": "nonce",
+            "type": "u64"
+          },
+          {
+            "name": "escrow_spent",
+            "docs": [
+              "Amount burned from the escrow vault."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "output_received",
+            "docs": [
+              "Amount minted to the owner's output ATA (levercoin for s2l, HYUSD for",
+              "l2s)."
+            ],
+            "type": {
+              "defined": {
+                "name": "UFixValue64"
+              }
+            }
+          },
+          {
+            "name": "output_mint",
+            "docs": [
+              "Mint of the output token (levercoin mint for s2l, HYUSD mint for l2s)."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "trigger_price",
+            "type": "i64"
+          },
+          {
+            "name": "trigger_expo",
+            "type": "i32"
+          },
+          {
+            "name": "direction",
+            "type": {
+              "defined": {
+                "name": "TriggerDirection"
+              }
+            }
+          },
+          {
+            "name": "pyth_price",
+            "docs": [
+              "Snapshotted at the trigger-check step, pre-CPI."
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "pyth_expo",
+            "type": "i32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "UFixValue64",
+      "docs": [
+        "A value-space `Fix` where base is always 10 and bits are a concrete type.",
+        "Intended for serialized storage in Solana accounts where generics won't work."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bits",
+            "type": "u64"
+          },
+          {
+            "name": "exp",
+            "type": "i8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "VerificationLevel",
+      "docs": [
+        "Pyth price updates are bridged to all blockchains via Wormhole.",
+        "Using the price updates on another chain requires verifying the signatures of the Wormhole guardians.",
+        "The usual process is to check the signatures for two thirds of the total number of guardians, but this can be cumbersome on Solana because of the transaction size limits,",
+        "so we also allow for partial verification.",
+        "",
+        "This enum represents how much a price update has been verified:",
+        "- If `Full`, we have verified the signatures for two thirds of the current guardians.",
+        "- If `Partial`, only `num_signatures` guardian signatures have been checked.",
+        "",
+        "# Warning",
+        "Using partially verified price updates is dangerous, as it lowers the threshold of guardians that need to collude to produce a malicious price update."
+      ],
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Partial",
+            "fields": [
+              {
+                "name": "num_signatures",
+                "type": "u8"
+              }
+            ]
+          },
+          {
+            "name": "Full"
+          }
+        ]
+      }
+    },
+    {
+      "name": "VirtualStablecoin",
+      "docs": [
+        "Simple counter representing the supply of a \"virtual\" stablecoin."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "supply",
+            "type": {
+              "defined": {
+                "name": "UFixValue64"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "YieldHarvestConfig",
+      "docs": [
+        "Captures yield harvest configuration as two basis point values:"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "allocation",
+            "type": {
+              "defined": {
+                "name": "UFixValue64"
+              }
+            }
+          },
+          {
+            "name": "fee",
+            "type": {
+              "defined": {
+                "name": "UFixValue64"
+              }
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "constants": [
+    {
+      "name": "EXECUTOR_TIP_LAMPORTS",
+      "docs": [
+        "Flat SOL tip paid to the executor on successful `execute_order_*`.",
+        "",
+        "Owner deposits this into the order PDA at `create_order_*` time (in",
+        "addition to the rent-exempt minimum). Executor receives these lamports",
+        "on successful execute. Cancel refunds the unused tip to the owner via",
+        "Anchor's `close = owner` on the order PDA.",
+        "",
+        "Sized to cover the executor's worst-case outlay (~0.00203 SOL ATA",
+        "donation + tx fee) with ~2.5x margin."
+      ],
+      "type": "u64",
+      "value": "5000000"
+    },
+    {
+      "name": "ORDER",
+      "docs": [
+        "Seed for `TriggerOrder` PDAs."
+      ],
+      "type": {
+        "array": [
+          "u8",
+          5
+        ]
+      },
+      "value": "[111, 114, 100, 101, 114]"
+    }
+  ]
+}

--- a/hylo-idl/idls/hylo_trigger_orders_shadow.json
+++ b/hylo-idl/idls/hylo_trigger_orders_shadow.json
@@ -1,0 +1,5528 @@
+{
+  "address": "4tgWjqeTdwjCrvHStnR5dzW8WGADRyAy7jkS32zNnJuM",
+  "metadata": {
+    "name": "hylo_trigger_orders",
+    "version": "1.0.0",
+    "spec": "0.1.0",
+    "description": "Hylo Trigger Orders Program"
+  },
+  "instructions": [
+    {
+      "name": "cancel_order_l2s_exo",
+      "discriminator": [
+        61,
+        165,
+        75,
+        198,
+        91,
+        170,
+        235,
+        153
+      ],
+      "accounts": [
+        {
+          "name": "owner",
+          "writable": true,
+          "signer": true,
+          "relations": [
+            "order"
+          ]
+        },
+        {
+          "name": "order",
+          "writable": true
+        },
+        {
+          "name": "order_levercoin_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "order"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "levercoin_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "owner_levercoin_ta",
+          "writable": true
+        },
+        {
+          "name": "levercoin_mint",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  101,
+                  120,
+                  111,
+                  95,
+                  108,
+                  101,
+                  118,
+                  101,
+                  114,
+                  99,
+                  111,
+                  105,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "collateral_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                245,
+                187,
+                72,
+                160,
+                4,
+                116,
+                48,
+                134,
+                197,
+                164,
+                152,
+                189,
+                233,
+                219,
+                27,
+                124,
+                201,
+                65,
+                103,
+                243,
+                58,
+                82,
+                140,
+                90,
+                13,
+                150,
+                83,
+                40,
+                223,
+                158,
+                124,
+                33
+              ]
+            }
+          }
+        },
+        {
+          "name": "collateral_mint",
+          "docs": [
+            "Defines the EXO pair the order targets. Validated against",
+            "`order.pair_target` via the `constraint` on `order` above."
+          ]
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95,
+                  95,
+                  101,
+                  118,
+                  101,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [],
+      "returns": {
+        "defined": {
+          "name": "TriggerOrderCancelled"
+        }
+      }
+    },
+    {
+      "name": "cancel_order_l2s_lst",
+      "discriminator": [
+        121,
+        201,
+        137,
+        113,
+        147,
+        216,
+        109,
+        177
+      ],
+      "accounts": [
+        {
+          "name": "owner",
+          "writable": true,
+          "signer": true,
+          "relations": [
+            "order"
+          ]
+        },
+        {
+          "name": "order",
+          "writable": true
+        },
+        {
+          "name": "order_xsol_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "order"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "xsol_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "owner_xsol_ta",
+          "writable": true
+        },
+        {
+          "name": "xsol_mint",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  120,
+                  83,
+                  79,
+                  76
+                ]
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                245,
+                187,
+                72,
+                160,
+                4,
+                116,
+                48,
+                134,
+                197,
+                164,
+                152,
+                189,
+                233,
+                219,
+                27,
+                124,
+                201,
+                65,
+                103,
+                243,
+                58,
+                82,
+                140,
+                90,
+                13,
+                150,
+                83,
+                40,
+                223,
+                158,
+                124,
+                33
+              ]
+            }
+          }
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95,
+                  95,
+                  101,
+                  118,
+                  101,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [],
+      "returns": {
+        "defined": {
+          "name": "TriggerOrderCancelled"
+        }
+      }
+    },
+    {
+      "name": "cancel_order_s2l",
+      "discriminator": [
+        85,
+        20,
+        75,
+        12,
+        198,
+        159,
+        196,
+        50
+      ],
+      "accounts": [
+        {
+          "name": "owner",
+          "writable": true,
+          "signer": true,
+          "relations": [
+            "order"
+          ]
+        },
+        {
+          "name": "order",
+          "writable": true
+        },
+        {
+          "name": "order_hyusd_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "order"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "hyusd_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "owner_hyusd_ta",
+          "writable": true
+        },
+        {
+          "name": "hyusd_mint",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  104,
+                  121,
+                  85,
+                  83,
+                  68
+                ]
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                245,
+                187,
+                72,
+                160,
+                4,
+                116,
+                48,
+                134,
+                197,
+                164,
+                152,
+                189,
+                233,
+                219,
+                27,
+                124,
+                201,
+                65,
+                103,
+                243,
+                58,
+                82,
+                140,
+                90,
+                13,
+                150,
+                83,
+                40,
+                223,
+                158,
+                124,
+                33
+              ]
+            }
+          }
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95,
+                  95,
+                  101,
+                  118,
+                  101,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [],
+      "returns": {
+        "defined": {
+          "name": "TriggerOrderCancelled"
+        }
+      }
+    },
+    {
+      "name": "create_order_l2s_exo",
+      "discriminator": [
+        145,
+        7,
+        163,
+        2,
+        20,
+        124,
+        128,
+        146
+      ],
+      "accounts": [
+        {
+          "name": "owner",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "order",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111,
+                  114,
+                  100,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "owner"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  1
+                ]
+              },
+              {
+                "kind": "const",
+                "value": [
+                  1
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "collateral_mint"
+              },
+              {
+                "kind": "arg",
+                "path": "nonce"
+              }
+            ]
+          }
+        },
+        {
+          "name": "order_levercoin_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "order"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "levercoin_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "owner_levercoin_ta",
+          "writable": true
+        },
+        {
+          "name": "levercoin_mint",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  101,
+                  120,
+                  111,
+                  95,
+                  108,
+                  101,
+                  118,
+                  101,
+                  114,
+                  99,
+                  111,
+                  105,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "collateral_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                245,
+                187,
+                72,
+                160,
+                4,
+                116,
+                48,
+                134,
+                197,
+                164,
+                152,
+                189,
+                233,
+                219,
+                27,
+                124,
+                201,
+                65,
+                103,
+                243,
+                58,
+                82,
+                140,
+                90,
+                13,
+                150,
+                83,
+                40,
+                223,
+                158,
+                124,
+                33
+              ]
+            }
+          }
+        },
+        {
+          "name": "collateral_mint",
+          "docs": [
+            "Defines the EXO pair the order targets.",
+            "",
+            "Intentionally **not** constrained to a registered `ExoPair`. The obvious",
+            "alternative would be to add a seed-derived `exo_pair: Account<ExoPair>`",
+            "to this struct and let Anchor validate. We don't, because:",
+            "",
+            "- **Cost is real.** Loading `ExoPair` adds one account to the create",
+            "instruction's account list (counts against the 64-account tx ceiling",
+            "shared with the rest of the tx), ~500 bytes of deserialization, and",
+            "commits this program to whatever Hylo's `ExoPair` schema looks like.",
+            "Hylo's `ExoPair` evolves (levercoin caps, fee curves, oracle config",
+            "have all been added over time); each evolution would force a",
+            "trigger-orders upgrade just to keep create working.",
+            "",
+            "- **Benefit is small.** Validation here is UX-only — it catches a",
+            "malformed mint at create instead of at execute. The owner's funds are",
+            "safe either way (see the three guarantees below).",
+            "",
+            "Why we can safely skip the check:",
+            "",
+            "1. The PDA seeds bind this mint cryptographically (see the `order` seeds",
+            "above), so a malformed mint creates a PDA at an address unique to that",
+            "owner/nonce/mint triple. No collision risk with other orders.",
+            "2. Only the owner is harmed by an unfillable order — their levercoin goes",
+            "into a PDA they alone can drain via `cancel_order_l2s_exo`. There's no",
+            "path for an attacker to lock anyone else's funds via this vector.",
+            "3. The cancel path doesn't read `ExoPair`, `Hylo`, or any pair-specific",
+            "state. So even if Hylo deprecates this collateral, the owner can",
+            "always recover. Funds-recoverability is structural, not policy.",
+            "",
+            "At execute time, the keeper passes the actual `ExoPair` account; it's",
+            "constrained to derive from this `collateral_mint`, so wrong-pair",
+            "execution attempts revert at account loading before any token movement."
+          ]
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "associated_token_program",
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "rent",
+          "address": "SysvarRent111111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95,
+                  95,
+                  101,
+                  118,
+                  101,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "nonce",
+          "type": "u64"
+        },
+        {
+          "name": "escrow_amount",
+          "type": "u64"
+        },
+        {
+          "name": "trigger_price",
+          "type": "i64"
+        },
+        {
+          "name": "trigger_expo",
+          "type": "i32"
+        },
+        {
+          "name": "direction",
+          "type": {
+            "defined": {
+              "name": "TriggerDirection"
+            }
+          }
+        }
+      ],
+      "returns": {
+        "defined": {
+          "name": "TriggerOrderCreated"
+        }
+      }
+    },
+    {
+      "name": "create_order_l2s_lst",
+      "discriminator": [
+        217,
+        157,
+        106,
+        121,
+        230,
+        232,
+        238,
+        73
+      ],
+      "accounts": [
+        {
+          "name": "owner",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "order",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111,
+                  114,
+                  100,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "owner"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  1
+                ]
+              },
+              {
+                "kind": "const",
+                "value": [
+                  0
+                ]
+              },
+              {
+                "kind": "arg",
+                "path": "nonce"
+              }
+            ]
+          }
+        },
+        {
+          "name": "order_xsol_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "order"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "xsol_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "owner_xsol_ta",
+          "writable": true
+        },
+        {
+          "name": "xsol_mint",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  120,
+                  83,
+                  79,
+                  76
+                ]
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                245,
+                187,
+                72,
+                160,
+                4,
+                116,
+                48,
+                134,
+                197,
+                164,
+                152,
+                189,
+                233,
+                219,
+                27,
+                124,
+                201,
+                65,
+                103,
+                243,
+                58,
+                82,
+                140,
+                90,
+                13,
+                150,
+                83,
+                40,
+                223,
+                158,
+                124,
+                33
+              ]
+            }
+          }
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "associated_token_program",
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "rent",
+          "address": "SysvarRent111111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95,
+                  95,
+                  101,
+                  118,
+                  101,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "nonce",
+          "type": "u64"
+        },
+        {
+          "name": "escrow_amount",
+          "type": "u64"
+        },
+        {
+          "name": "trigger_price",
+          "type": "i64"
+        },
+        {
+          "name": "trigger_expo",
+          "type": "i32"
+        },
+        {
+          "name": "direction",
+          "type": {
+            "defined": {
+              "name": "TriggerDirection"
+            }
+          }
+        }
+      ],
+      "returns": {
+        "defined": {
+          "name": "TriggerOrderCreated"
+        }
+      }
+    },
+    {
+      "name": "create_order_s2l_exo",
+      "discriminator": [
+        102,
+        197,
+        120,
+        21,
+        57,
+        139,
+        195,
+        202
+      ],
+      "accounts": [
+        {
+          "name": "owner",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "order",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111,
+                  114,
+                  100,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "owner"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  0
+                ]
+              },
+              {
+                "kind": "const",
+                "value": [
+                  1
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "collateral_mint"
+              },
+              {
+                "kind": "arg",
+                "path": "nonce"
+              }
+            ]
+          }
+        },
+        {
+          "name": "order_hyusd_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "order"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "hyusd_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "owner_hyusd_ta",
+          "writable": true
+        },
+        {
+          "name": "hyusd_mint",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  104,
+                  121,
+                  85,
+                  83,
+                  68
+                ]
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                245,
+                187,
+                72,
+                160,
+                4,
+                116,
+                48,
+                134,
+                197,
+                164,
+                152,
+                189,
+                233,
+                219,
+                27,
+                124,
+                201,
+                65,
+                103,
+                243,
+                58,
+                82,
+                140,
+                90,
+                13,
+                150,
+                83,
+                40,
+                223,
+                158,
+                124,
+                33
+              ]
+            }
+          }
+        },
+        {
+          "name": "collateral_mint",
+          "docs": [
+            "Defines the EXO pair the order targets.",
+            "",
+            "Intentionally **not** constrained to a registered `ExoPair`. The obvious",
+            "alternative would be to add a seed-derived `exo_pair: Account<ExoPair>`",
+            "to this struct and let Anchor validate. We don't, because:",
+            "",
+            "- **Cost is real.** Loading `ExoPair` adds one account to the create",
+            "instruction's account list (counts against the 64-account tx ceiling",
+            "shared with the rest of the tx), ~500 bytes of deserialization, and",
+            "commits this program to whatever Hylo's `ExoPair` schema looks like.",
+            "Hylo's `ExoPair` evolves (levercoin caps, fee curves, oracle config",
+            "have all been added over time); each evolution would force a",
+            "trigger-orders upgrade just to keep create working.",
+            "",
+            "- **Benefit is small.** Validation here is UX-only — it catches a",
+            "malformed mint at create instead of at execute. The owner's funds are",
+            "safe either way (see the three guarantees below).",
+            "",
+            "Why we can safely skip the check:",
+            "",
+            "1. The PDA seeds bind this mint cryptographically (see the `order` seeds",
+            "above), so a malformed mint creates a PDA at an address unique to that",
+            "owner/nonce/mint triple. No collision risk with other orders.",
+            "2. Only the owner is harmed by an unfillable order — their HYUSD goes",
+            "into a PDA they alone can drain via `cancel_order_s2l`. There's no",
+            "path for an attacker to lock anyone else's funds via this vector.",
+            "3. The cancel path doesn't read `ExoPair`, `Hylo`, or any pair-specific",
+            "state. So even if Hylo deprecates this collateral, the owner can",
+            "always recover. Funds-recoverability is structural, not policy.",
+            "",
+            "At execute time, the keeper passes the actual `ExoPair` account; it's",
+            "constrained to derive from this `collateral_mint`, so wrong-pair",
+            "execution attempts revert at account loading before any token movement."
+          ]
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "associated_token_program",
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "rent",
+          "address": "SysvarRent111111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95,
+                  95,
+                  101,
+                  118,
+                  101,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "nonce",
+          "type": "u64"
+        },
+        {
+          "name": "escrow_amount",
+          "type": "u64"
+        },
+        {
+          "name": "trigger_price",
+          "type": "i64"
+        },
+        {
+          "name": "trigger_expo",
+          "type": "i32"
+        },
+        {
+          "name": "direction",
+          "type": {
+            "defined": {
+              "name": "TriggerDirection"
+            }
+          }
+        }
+      ],
+      "returns": {
+        "defined": {
+          "name": "TriggerOrderCreated"
+        }
+      }
+    },
+    {
+      "name": "create_order_s2l_lst",
+      "discriminator": [
+        1,
+        195,
+        39,
+        158,
+        147,
+        192,
+        10,
+        101
+      ],
+      "accounts": [
+        {
+          "name": "owner",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "order",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111,
+                  114,
+                  100,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "owner"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  0
+                ]
+              },
+              {
+                "kind": "const",
+                "value": [
+                  0
+                ]
+              },
+              {
+                "kind": "arg",
+                "path": "nonce"
+              }
+            ]
+          }
+        },
+        {
+          "name": "order_hyusd_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "order"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "hyusd_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "owner_hyusd_ta",
+          "writable": true
+        },
+        {
+          "name": "hyusd_mint",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  104,
+                  121,
+                  85,
+                  83,
+                  68
+                ]
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                245,
+                187,
+                72,
+                160,
+                4,
+                116,
+                48,
+                134,
+                197,
+                164,
+                152,
+                189,
+                233,
+                219,
+                27,
+                124,
+                201,
+                65,
+                103,
+                243,
+                58,
+                82,
+                140,
+                90,
+                13,
+                150,
+                83,
+                40,
+                223,
+                158,
+                124,
+                33
+              ]
+            }
+          }
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "associated_token_program",
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "rent",
+          "address": "SysvarRent111111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95,
+                  95,
+                  101,
+                  118,
+                  101,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "nonce",
+          "type": "u64"
+        },
+        {
+          "name": "escrow_amount",
+          "type": "u64"
+        },
+        {
+          "name": "trigger_price",
+          "type": "i64"
+        },
+        {
+          "name": "trigger_expo",
+          "type": "i32"
+        },
+        {
+          "name": "direction",
+          "type": {
+            "defined": {
+              "name": "TriggerDirection"
+            }
+          }
+        }
+      ],
+      "returns": {
+        "defined": {
+          "name": "TriggerOrderCreated"
+        }
+      }
+    },
+    {
+      "name": "execute_order_l2s_exo",
+      "discriminator": [
+        112,
+        175,
+        205,
+        216,
+        129,
+        95,
+        184,
+        153
+      ],
+      "accounts": [
+        {
+          "name": "executor",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "owner",
+          "writable": true,
+          "relations": [
+            "order"
+          ]
+        },
+        {
+          "name": "hylo"
+        },
+        {
+          "name": "exo_pair",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  101,
+                  120,
+                  111,
+                  95,
+                  112,
+                  97,
+                  105,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "collateral_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                245,
+                187,
+                72,
+                160,
+                4,
+                116,
+                48,
+                134,
+                197,
+                164,
+                152,
+                189,
+                233,
+                219,
+                27,
+                124,
+                201,
+                65,
+                103,
+                243,
+                58,
+                82,
+                140,
+                90,
+                13,
+                150,
+                83,
+                40,
+                223,
+                158,
+                124,
+                33
+              ]
+            }
+          }
+        },
+        {
+          "name": "collateral_mint",
+          "relations": [
+            "exo_pair"
+          ]
+        },
+        {
+          "name": "vault_auth"
+        },
+        {
+          "name": "collateral_vault",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "vault_auth"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "collateral_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "collateral_usd_pyth_feed"
+        },
+        {
+          "name": "hyusd_mint",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  104,
+                  121,
+                  85,
+                  83,
+                  68
+                ]
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                245,
+                187,
+                72,
+                160,
+                4,
+                116,
+                48,
+                134,
+                197,
+                164,
+                152,
+                189,
+                233,
+                219,
+                27,
+                124,
+                201,
+                65,
+                103,
+                243,
+                58,
+                82,
+                140,
+                90,
+                13,
+                150,
+                83,
+                40,
+                223,
+                158,
+                124,
+                33
+              ]
+            }
+          }
+        },
+        {
+          "name": "stablecoin_auth"
+        },
+        {
+          "name": "fee_auth"
+        },
+        {
+          "name": "fee_vault",
+          "writable": true
+        },
+        {
+          "name": "levercoin_mint",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  101,
+                  120,
+                  111,
+                  95,
+                  108,
+                  101,
+                  118,
+                  101,
+                  114,
+                  99,
+                  111,
+                  105,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "collateral_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                245,
+                187,
+                72,
+                160,
+                4,
+                116,
+                48,
+                134,
+                197,
+                164,
+                152,
+                189,
+                233,
+                219,
+                27,
+                124,
+                201,
+                65,
+                103,
+                243,
+                58,
+                82,
+                140,
+                90,
+                13,
+                150,
+                83,
+                40,
+                223,
+                158,
+                124,
+                33
+              ]
+            }
+          }
+        },
+        {
+          "name": "levercoin_auth"
+        },
+        {
+          "name": "order",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111,
+                  114,
+                  100,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "order.owner",
+                "account": "TriggerOrder"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  1
+                ]
+              },
+              {
+                "kind": "const",
+                "value": [
+                  1
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "collateral_mint"
+              },
+              {
+                "kind": "account",
+                "path": "order.nonce",
+                "account": "TriggerOrder"
+              }
+            ]
+          }
+        },
+        {
+          "name": "order_levercoin_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "order"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "levercoin_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "order_hyusd_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "order"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "hyusd_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "owner_hyusd_ta",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "owner"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "hyusd_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "hylo_exchange_event_authority"
+        },
+        {
+          "name": "hylo_exchange_program",
+          "address": "HYEXCHtHkBagdStcJCp3xbbb9B7sdMdWXFNj6mdsG4hn"
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "associated_token_program",
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95,
+                  95,
+                  101,
+                  118,
+                  101,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [],
+      "returns": {
+        "defined": {
+          "name": "TriggerOrderFilled"
+        }
+      }
+    },
+    {
+      "name": "execute_order_l2s_lst",
+      "discriminator": [
+        96,
+        37,
+        224,
+        31,
+        190,
+        139,
+        223,
+        0
+      ],
+      "accounts": [
+        {
+          "name": "executor",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "owner",
+          "writable": true,
+          "relations": [
+            "order"
+          ]
+        },
+        {
+          "name": "hylo",
+          "writable": true
+        },
+        {
+          "name": "sol_usd_pyth_feed"
+        },
+        {
+          "name": "hyusd_mint",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  104,
+                  121,
+                  85,
+                  83,
+                  68
+                ]
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                245,
+                187,
+                72,
+                160,
+                4,
+                116,
+                48,
+                134,
+                197,
+                164,
+                152,
+                189,
+                233,
+                219,
+                27,
+                124,
+                201,
+                65,
+                103,
+                243,
+                58,
+                82,
+                140,
+                90,
+                13,
+                150,
+                83,
+                40,
+                223,
+                158,
+                124,
+                33
+              ]
+            }
+          }
+        },
+        {
+          "name": "stablecoin_auth"
+        },
+        {
+          "name": "fee_auth"
+        },
+        {
+          "name": "fee_vault",
+          "writable": true
+        },
+        {
+          "name": "xsol_mint",
+          "writable": true
+        },
+        {
+          "name": "levercoin_auth"
+        },
+        {
+          "name": "order",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111,
+                  114,
+                  100,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "order.owner",
+                "account": "TriggerOrder"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  1
+                ]
+              },
+              {
+                "kind": "const",
+                "value": [
+                  0
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "order.nonce",
+                "account": "TriggerOrder"
+              }
+            ]
+          }
+        },
+        {
+          "name": "order_xsol_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "order"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "xsol_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "order_hyusd_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "order"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "hyusd_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "owner_hyusd_ta",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "owner"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "hyusd_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "hylo_exchange_event_authority"
+        },
+        {
+          "name": "hylo_exchange_program",
+          "address": "HYEXCHtHkBagdStcJCp3xbbb9B7sdMdWXFNj6mdsG4hn"
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "associated_token_program",
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95,
+                  95,
+                  101,
+                  118,
+                  101,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [],
+      "returns": {
+        "defined": {
+          "name": "TriggerOrderFilled"
+        }
+      }
+    },
+    {
+      "name": "execute_order_s2l_exo",
+      "discriminator": [
+        29,
+        184,
+        147,
+        164,
+        106,
+        9,
+        121,
+        21
+      ],
+      "accounts": [
+        {
+          "name": "executor",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "owner",
+          "writable": true,
+          "relations": [
+            "order"
+          ]
+        },
+        {
+          "name": "hylo"
+        },
+        {
+          "name": "exo_pair",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  101,
+                  120,
+                  111,
+                  95,
+                  112,
+                  97,
+                  105,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "collateral_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                245,
+                187,
+                72,
+                160,
+                4,
+                116,
+                48,
+                134,
+                197,
+                164,
+                152,
+                189,
+                233,
+                219,
+                27,
+                124,
+                201,
+                65,
+                103,
+                243,
+                58,
+                82,
+                140,
+                90,
+                13,
+                150,
+                83,
+                40,
+                223,
+                158,
+                124,
+                33
+              ]
+            }
+          }
+        },
+        {
+          "name": "collateral_mint",
+          "relations": [
+            "exo_pair"
+          ]
+        },
+        {
+          "name": "vault_auth"
+        },
+        {
+          "name": "collateral_vault",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "vault_auth"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "collateral_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "collateral_usd_pyth_feed"
+        },
+        {
+          "name": "hyusd_mint",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  104,
+                  121,
+                  85,
+                  83,
+                  68
+                ]
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                245,
+                187,
+                72,
+                160,
+                4,
+                116,
+                48,
+                134,
+                197,
+                164,
+                152,
+                189,
+                233,
+                219,
+                27,
+                124,
+                201,
+                65,
+                103,
+                243,
+                58,
+                82,
+                140,
+                90,
+                13,
+                150,
+                83,
+                40,
+                223,
+                158,
+                124,
+                33
+              ]
+            }
+          }
+        },
+        {
+          "name": "stablecoin_auth"
+        },
+        {
+          "name": "fee_auth"
+        },
+        {
+          "name": "fee_vault",
+          "writable": true
+        },
+        {
+          "name": "levercoin_mint",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  101,
+                  120,
+                  111,
+                  95,
+                  108,
+                  101,
+                  118,
+                  101,
+                  114,
+                  99,
+                  111,
+                  105,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "collateral_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                245,
+                187,
+                72,
+                160,
+                4,
+                116,
+                48,
+                134,
+                197,
+                164,
+                152,
+                189,
+                233,
+                219,
+                27,
+                124,
+                201,
+                65,
+                103,
+                243,
+                58,
+                82,
+                140,
+                90,
+                13,
+                150,
+                83,
+                40,
+                223,
+                158,
+                124,
+                33
+              ]
+            }
+          }
+        },
+        {
+          "name": "levercoin_auth"
+        },
+        {
+          "name": "order",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111,
+                  114,
+                  100,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "order.owner",
+                "account": "TriggerOrder"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  0
+                ]
+              },
+              {
+                "kind": "const",
+                "value": [
+                  1
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "collateral_mint"
+              },
+              {
+                "kind": "account",
+                "path": "order.nonce",
+                "account": "TriggerOrder"
+              }
+            ]
+          }
+        },
+        {
+          "name": "order_hyusd_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "order"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "hyusd_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "order_levercoin_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "order"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "levercoin_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "owner_levercoin_ta",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "owner"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "levercoin_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "hylo_exchange_event_authority"
+        },
+        {
+          "name": "hylo_exchange_program",
+          "address": "HYEXCHtHkBagdStcJCp3xbbb9B7sdMdWXFNj6mdsG4hn"
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "associated_token_program",
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95,
+                  95,
+                  101,
+                  118,
+                  101,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [],
+      "returns": {
+        "defined": {
+          "name": "TriggerOrderFilled"
+        }
+      }
+    },
+    {
+      "name": "execute_order_s2l_lst",
+      "discriminator": [
+        26,
+        104,
+        100,
+        203,
+        82,
+        5,
+        112,
+        58
+      ],
+      "accounts": [
+        {
+          "name": "executor",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "owner",
+          "writable": true,
+          "relations": [
+            "order"
+          ]
+        },
+        {
+          "name": "hylo",
+          "writable": true
+        },
+        {
+          "name": "sol_usd_pyth_feed"
+        },
+        {
+          "name": "hyusd_mint",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  104,
+                  121,
+                  85,
+                  83,
+                  68
+                ]
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                245,
+                187,
+                72,
+                160,
+                4,
+                116,
+                48,
+                134,
+                197,
+                164,
+                152,
+                189,
+                233,
+                219,
+                27,
+                124,
+                201,
+                65,
+                103,
+                243,
+                58,
+                82,
+                140,
+                90,
+                13,
+                150,
+                83,
+                40,
+                223,
+                158,
+                124,
+                33
+              ]
+            }
+          }
+        },
+        {
+          "name": "stablecoin_auth"
+        },
+        {
+          "name": "fee_auth"
+        },
+        {
+          "name": "fee_vault",
+          "writable": true
+        },
+        {
+          "name": "xsol_mint",
+          "writable": true
+        },
+        {
+          "name": "levercoin_auth"
+        },
+        {
+          "name": "order",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111,
+                  114,
+                  100,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "order.owner",
+                "account": "TriggerOrder"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  0
+                ]
+              },
+              {
+                "kind": "const",
+                "value": [
+                  0
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "order.nonce",
+                "account": "TriggerOrder"
+              }
+            ]
+          }
+        },
+        {
+          "name": "order_hyusd_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "order"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "hyusd_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "order_xsol_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "order"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "xsol_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "owner_xsol_ta",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "owner"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "xsol_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "hylo_exchange_event_authority"
+        },
+        {
+          "name": "hylo_exchange_program",
+          "address": "HYEXCHtHkBagdStcJCp3xbbb9B7sdMdWXFNj6mdsG4hn"
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "associated_token_program",
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95,
+                  95,
+                  101,
+                  118,
+                  101,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [],
+      "returns": {
+        "defined": {
+          "name": "TriggerOrderFilled"
+        }
+      }
+    }
+  ],
+  "accounts": [
+    {
+      "name": "ExoPair",
+      "discriminator": [
+        251,
+        244,
+        72,
+        181,
+        40,
+        119,
+        232,
+        48
+      ]
+    },
+    {
+      "name": "Hylo",
+      "discriminator": [
+        114,
+        161,
+        169,
+        210,
+        204,
+        175,
+        149,
+        174
+      ]
+    },
+    {
+      "name": "PriceUpdateV2",
+      "discriminator": [
+        34,
+        241,
+        35,
+        99,
+        157,
+        126,
+        244,
+        205
+      ]
+    },
+    {
+      "name": "TriggerOrder",
+      "discriminator": [
+        236,
+        61,
+        42,
+        190,
+        152,
+        12,
+        106,
+        116
+      ]
+    }
+  ],
+  "events": [
+    {
+      "name": "TriggerOrderCancelled",
+      "discriminator": [
+        255,
+        151,
+        206,
+        140,
+        98,
+        153,
+        223,
+        121
+      ]
+    },
+    {
+      "name": "TriggerOrderCreated",
+      "discriminator": [
+        90,
+        78,
+        39,
+        34,
+        130,
+        168,
+        79,
+        55
+      ]
+    },
+    {
+      "name": "TriggerOrderFilled",
+      "discriminator": [
+        124,
+        156,
+        201,
+        86,
+        158,
+        86,
+        183,
+        212
+      ]
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "AmountTooSmall",
+      "msg": "escrow_amount must be > 0"
+    },
+    {
+      "code": 6001,
+      "name": "AccountMismatch",
+      "msg": "account does not match the order's pair target"
+    },
+    {
+      "code": 6002,
+      "name": "TriggerNotMet",
+      "msg": "price condition not met"
+    },
+    {
+      "code": 6003,
+      "name": "Unauthorized",
+      "msg": "signer is not the order owner"
+    },
+    {
+      "code": 6004,
+      "name": "InvalidPythPrice",
+      "msg": "invalid pyth price update account, feed id, or expo"
+    }
+  ],
+  "types": [
+    {
+      "name": "BorrowRateConfig",
+      "docs": [
+        "Per-epoch borrow rate for exogenous collateral without native yield."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "rate",
+            "type": {
+              "defined": {
+                "name": "UFixValue64"
+              }
+            }
+          },
+          {
+            "name": "fee",
+            "type": {
+              "defined": {
+                "name": "UFixValue64"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ConvertDirection",
+      "docs": [
+        "Direction of the underlying Hylo convert ix the trigger order will fire.",
+        "`StableToLever` burns HYUSD to mint levercoin (the v1 direction).",
+        "`LeverToStable` burns levercoin to mint HYUSD (v1.1 addition)."
+      ],
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "StableToLever"
+          },
+          {
+            "name": "LeverToStable"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ExoPair",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "collateral_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "levercoin_mint_bump",
+            "type": "u8"
+          },
+          {
+            "name": "levercoin_auth_bump",
+            "type": "u8"
+          },
+          {
+            "name": "vault_auth_bump",
+            "type": "u8"
+          },
+          {
+            "name": "fee_auth_bump",
+            "type": "u8"
+          },
+          {
+            "name": "oracle",
+            "type": "pubkey"
+          },
+          {
+            "name": "oracle_feed_id",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "oracle_interval_secs",
+            "type": "u64"
+          },
+          {
+            "name": "oracle_conf_tolerance",
+            "type": {
+              "defined": {
+                "name": "UFixValue64"
+              }
+            }
+          },
+          {
+            "name": "stablecoin_mint_threshold",
+            "type": {
+              "defined": {
+                "name": "UFixValue64"
+              }
+            }
+          },
+          {
+            "name": "virtual_stablecoin",
+            "type": {
+              "defined": {
+                "name": "VirtualStablecoin"
+              }
+            }
+          },
+          {
+            "name": "borrow_rate_config",
+            "type": {
+              "defined": {
+                "name": "BorrowRateConfig"
+              }
+            }
+          },
+          {
+            "name": "borrow_rate_harvest_cache",
+            "type": {
+              "defined": {
+                "name": "HarvestCache"
+              }
+            }
+          },
+          {
+            "name": "levercoin_fees",
+            "type": {
+              "defined": {
+                "name": "LevercoinFees"
+              }
+            }
+          },
+          {
+            "name": "sell_curve_config",
+            "type": {
+              "defined": {
+                "name": "RebalanceCurveConfig"
+              }
+            }
+          },
+          {
+            "name": "buy_curve_config",
+            "type": {
+              "defined": {
+                "name": "RebalanceCurveConfig"
+              }
+            }
+          },
+          {
+            "name": "rebalance_deviation_tolerance",
+            "type": {
+              "defined": {
+                "name": "UFixValue64"
+              }
+            }
+          },
+          {
+            "name": "paused",
+            "type": "bool"
+          },
+          {
+            "name": "levercoin_market_cap_limit",
+            "type": {
+              "defined": {
+                "name": "UFixValue64"
+              }
+            }
+          },
+          {
+            "name": "pool_drawdown",
+            "type": {
+              "defined": {
+                "name": "PoolDrawdown"
+              }
+            }
+          },
+          {
+            "name": "_reserved",
+            "type": {
+              "array": [
+                "u8",
+                100
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "FeePair",
+      "docs": [
+        "Represents the spread of fees between mint and redeem for protocol tokens.",
+        "All fees must be in basis points to represent a fractional percentage",
+        "directly applicable to a token amount e.g. `0.XXXX` or `bips x 10^-4`."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "mint",
+            "type": {
+              "defined": {
+                "name": "UFixValue64"
+              }
+            }
+          },
+          {
+            "name": "redeem",
+            "type": {
+              "defined": {
+                "name": "UFixValue64"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "HarvestCache",
+      "docs": [
+        "Records epoch harvest information for off-chain consumers."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "epoch",
+            "type": "u64"
+          },
+          {
+            "name": "stability_pool_cap",
+            "type": {
+              "defined": {
+                "name": "UFixValue64"
+              }
+            }
+          },
+          {
+            "name": "stablecoin_to_pool",
+            "type": {
+              "defined": {
+                "name": "UFixValue64"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Hylo",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "admin",
+            "type": "pubkey"
+          },
+          {
+            "name": "treasury",
+            "type": "pubkey"
+          },
+          {
+            "name": "lst_registry",
+            "type": "pubkey"
+          },
+          {
+            "name": "stablecoin_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "levercoin_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "pause_authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "stablecoin_mint_bump",
+            "type": "u8"
+          },
+          {
+            "name": "stablecoin_auth_bump",
+            "type": "u8"
+          },
+          {
+            "name": "levercoin_mint_bump",
+            "type": "u8"
+          },
+          {
+            "name": "levercoin_auth_bump",
+            "type": "u8"
+          },
+          {
+            "name": "registry_auth_bump",
+            "type": "u8"
+          },
+          {
+            "name": "total_sol_cache_bump",
+            "type": "u8"
+          },
+          {
+            "name": "oracle_interval_secs",
+            "type": "u64"
+          },
+          {
+            "name": "stablecoin_fees",
+            "type": {
+              "defined": {
+                "name": "StablecoinFees"
+              }
+            }
+          },
+          {
+            "name": "levercoin_fees",
+            "type": {
+              "defined": {
+                "name": "LevercoinFees"
+              }
+            }
+          },
+          {
+            "name": "total_sol_cache",
+            "type": {
+              "defined": {
+                "name": "TotalSolCache"
+              }
+            }
+          },
+          {
+            "name": "yield_harvest_cache",
+            "type": {
+              "defined": {
+                "name": "HarvestCache"
+              }
+            }
+          },
+          {
+            "name": "yield_harvest_config",
+            "type": {
+              "defined": {
+                "name": "YieldHarvestConfig"
+              }
+            }
+          },
+          {
+            "name": "stablecoin_mint_threshold",
+            "type": {
+              "defined": {
+                "name": "UFixValue64"
+              }
+            }
+          },
+          {
+            "name": "_legacy_stability_threshold_2",
+            "type": {
+              "defined": {
+                "name": "UFixValue64"
+              }
+            }
+          },
+          {
+            "name": "oracle_conf_tolerance",
+            "type": {
+              "defined": {
+                "name": "UFixValue64"
+              }
+            }
+          },
+          {
+            "name": "sol_usd_oracle",
+            "type": "pubkey"
+          },
+          {
+            "name": "lst_swap_fee",
+            "type": {
+              "defined": {
+                "name": "UFixValue64"
+              }
+            }
+          },
+          {
+            "name": "virtual_stablecoin",
+            "type": {
+              "defined": {
+                "name": "VirtualStablecoin"
+              }
+            }
+          },
+          {
+            "name": "lst_buy_curve_config",
+            "type": {
+              "defined": {
+                "name": "RebalanceCurveConfig"
+              }
+            }
+          },
+          {
+            "name": "lst_sell_curve_config",
+            "type": {
+              "defined": {
+                "name": "RebalanceCurveConfig"
+              }
+            }
+          },
+          {
+            "name": "protocol_paused",
+            "type": "bool"
+          },
+          {
+            "name": "lst_pair_paused",
+            "type": "bool"
+          },
+          {
+            "name": "rebalance_deviation_tolerance",
+            "type": {
+              "defined": {
+                "name": "UFixValue64"
+              }
+            }
+          },
+          {
+            "name": "pool_drawdown",
+            "type": {
+              "defined": {
+                "name": "PoolDrawdown"
+              }
+            }
+          },
+          {
+            "name": "_reserved",
+            "type": {
+              "array": [
+                "u8",
+                13
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "LevercoinFees",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "normal",
+            "type": {
+              "defined": {
+                "name": "FeePair"
+              }
+            }
+          },
+          {
+            "name": "sell_zone_1",
+            "type": {
+              "defined": {
+                "name": "FeePair"
+              }
+            }
+          },
+          {
+            "name": "sell_zone_2",
+            "type": {
+              "defined": {
+                "name": "FeePair"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PairTarget",
+      "docs": [
+        "Which Hylo pair an order targets: an LST pair (output xSOL) or an EXO",
+        "pair (output the per-collateral xASSET)."
+      ],
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Lst"
+          },
+          {
+            "name": "Exo",
+            "fields": [
+              {
+                "name": "collateral_mint",
+                "type": "pubkey"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "PoolDrawdown",
+      "docs": [
+        "Outstanding hyUSD debt owed to the earn pool after a Depeg absorption."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "ledger",
+            "type": {
+              "defined": {
+                "name": "VirtualStablecoin"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PriceFeedMessage",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "feed_id",
+            "docs": [
+              "`FeedId` but avoid the type alias because of compatibility issues with Anchor's `idl-build` feature."
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "price",
+            "type": "i64"
+          },
+          {
+            "name": "conf",
+            "type": "u64"
+          },
+          {
+            "name": "exponent",
+            "type": "i32"
+          },
+          {
+            "name": "publish_time",
+            "docs": [
+              "The timestamp of this price update in seconds"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "prev_publish_time",
+            "docs": [
+              "The timestamp of the previous price update. This field is intended to allow users to",
+              "identify the single unique price update for any moment in time:",
+              "for any time t, the unique update is the one such that prev_publish_time < t <= publish_time.",
+              "",
+              "Note that there may not be such an update while we are migrating to the new message-sending logic,",
+              "as some price updates on pythnet may not be sent to other chains (because the message-sending",
+              "logic may not have triggered). We can solve this problem by making the message-sending mandatory",
+              "(which we can do once publishers have migrated over).",
+              "",
+              "Additionally, this field may be equal to publish_time if the message is sent on a slot where",
+              "where the aggregation was unsuccesful. This problem will go away once all publishers have",
+              "migrated over to a recent version of pyth-agent."
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "ema_price",
+            "type": "i64"
+          },
+          {
+            "name": "ema_conf",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PriceUpdateV2",
+      "docs": [
+        "A price update account. This account is used by the Pyth Receiver program to store a verified price update from a Pyth price feed.",
+        "It contains:",
+        "- `write_authority`: The write authority for this account. This authority can close this account to reclaim rent or update the account to contain a different price update.",
+        "- `verification_level`: The [`VerificationLevel`] of this price update. This represents how many Wormhole guardian signatures have been verified for this price update.",
+        "- `price_message`: The actual price update.",
+        "- `posted_slot`: The slot at which this price update was posted."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "write_authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "verification_level",
+            "type": {
+              "defined": {
+                "name": "VerificationLevel"
+              }
+            }
+          },
+          {
+            "name": "price_message",
+            "type": {
+              "defined": {
+                "name": "PriceFeedMessage"
+              }
+            }
+          },
+          {
+            "name": "posted_slot",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RebalanceCurveConfig",
+      "docs": [
+        "Confidence interval multipliers for rebalance price curve construction."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "floor_mult",
+            "type": {
+              "defined": {
+                "name": "UFixValue64"
+              }
+            }
+          },
+          {
+            "name": "ceil_mult",
+            "type": {
+              "defined": {
+                "name": "UFixValue64"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "StablecoinFees",
+      "docs": [
+        "**Deprecated** — retained only for `Hylo` account deserialization."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "normal",
+            "type": {
+              "defined": {
+                "name": "FeePair"
+              }
+            }
+          },
+          {
+            "name": "mode_1",
+            "type": {
+              "defined": {
+                "name": "FeePair"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "TotalSolCache",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "current_update_epoch",
+            "type": "u64"
+          },
+          {
+            "name": "total_sol",
+            "type": {
+              "defined": {
+                "name": "UFixValue64"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "TriggerDirection",
+      "docs": [
+        "Direction of a trigger order: fill when the underlying price is at or",
+        "below the trigger, or at or above."
+      ],
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "AtOrBelow"
+          },
+          {
+            "name": "AtOrAbove"
+          }
+        ]
+      }
+    },
+    {
+      "name": "TriggerOrder",
+      "docs": [
+        "Per-order escrow account holding the user's escrow + trigger parameters."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "owner",
+            "docs": [
+              "Owner can cancel; receives output on fill."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "pair_target",
+            "type": {
+              "defined": {
+                "name": "PairTarget"
+              }
+            }
+          },
+          {
+            "name": "convert_direction",
+            "docs": [
+              "Direction of the Hylo convert ix this order will fire (s2l or l2s)."
+            ],
+            "type": {
+              "defined": {
+                "name": "ConvertDirection"
+              }
+            }
+          },
+          {
+            "name": "nonce",
+            "docs": [
+              "Client-chosen; `(owner, convert_direction, pair_target, nonce)` is",
+              "unique."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "escrow_amount",
+            "docs": [
+              "Amount escrowed in the order's escrow vault. Unit depends on",
+              "`convert_direction`: HYUSD for s2l; xSOL or per-EXO levercoin for l2s."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "trigger_price",
+            "docs": [
+              "Pyth-style price."
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "trigger_expo",
+            "docs": [
+              "Pyth-style exponent."
+            ],
+            "type": "i32"
+          },
+          {
+            "name": "direction",
+            "type": {
+              "defined": {
+                "name": "TriggerDirection"
+              }
+            }
+          },
+          {
+            "name": "created_at",
+            "docs": [
+              "Unix timestamp from Anchor's `Clock` at create."
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "TriggerOrderCancelled",
+      "docs": [
+        "Emitted at the end of `cancel_order_{s2l,l2s_lst,l2s_exo}` after the",
+        "refund completes."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "order",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "pair_target",
+            "type": {
+              "defined": {
+                "name": "PairTarget"
+              }
+            }
+          },
+          {
+            "name": "convert_direction",
+            "type": {
+              "defined": {
+                "name": "ConvertDirection"
+              }
+            }
+          },
+          {
+            "name": "nonce",
+            "type": "u64"
+          },
+          {
+            "name": "escrow_refunded",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "TriggerOrderCreated",
+      "docs": [
+        "Emitted at the end of `create_order_{s2l,l2s}_{lst,exo}` after state",
+        "mutations succeed."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "order",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "pair_target",
+            "type": {
+              "defined": {
+                "name": "PairTarget"
+              }
+            }
+          },
+          {
+            "name": "convert_direction",
+            "type": {
+              "defined": {
+                "name": "ConvertDirection"
+              }
+            }
+          },
+          {
+            "name": "nonce",
+            "type": "u64"
+          },
+          {
+            "name": "escrow_amount",
+            "docs": [
+              "Amount escrowed (HYUSD for s2l, levercoin for l2s)."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "trigger_price",
+            "type": "i64"
+          },
+          {
+            "name": "trigger_expo",
+            "type": "i32"
+          },
+          {
+            "name": "direction",
+            "type": {
+              "defined": {
+                "name": "TriggerDirection"
+              }
+            }
+          },
+          {
+            "name": "created_at",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "TriggerOrderFilled",
+      "docs": [
+        "Emitted at the end of `execute_order_{s2l,l2s}_{lst,exo}` after the order",
+        "fills. `output_received` mirrors Hylo's convert event field",
+        "(`UFixValue64`) verbatim."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "order",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "executor",
+            "type": "pubkey"
+          },
+          {
+            "name": "pair_target",
+            "type": {
+              "defined": {
+                "name": "PairTarget"
+              }
+            }
+          },
+          {
+            "name": "convert_direction",
+            "type": {
+              "defined": {
+                "name": "ConvertDirection"
+              }
+            }
+          },
+          {
+            "name": "nonce",
+            "type": "u64"
+          },
+          {
+            "name": "escrow_spent",
+            "docs": [
+              "Amount burned from the escrow vault."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "output_received",
+            "docs": [
+              "Amount minted to the owner's output ATA (levercoin for s2l, HYUSD for",
+              "l2s)."
+            ],
+            "type": {
+              "defined": {
+                "name": "UFixValue64"
+              }
+            }
+          },
+          {
+            "name": "output_mint",
+            "docs": [
+              "Mint of the output token (levercoin mint for s2l, HYUSD mint for l2s)."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "trigger_price",
+            "type": "i64"
+          },
+          {
+            "name": "trigger_expo",
+            "type": "i32"
+          },
+          {
+            "name": "direction",
+            "type": {
+              "defined": {
+                "name": "TriggerDirection"
+              }
+            }
+          },
+          {
+            "name": "pyth_price",
+            "docs": [
+              "Snapshotted at the trigger-check step, pre-CPI."
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "pyth_expo",
+            "type": "i32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "UFixValue64",
+      "docs": [
+        "A value-space `Fix` where base is always 10 and bits are a concrete type.",
+        "Intended for serialized storage in Solana accounts where generics won't work."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bits",
+            "type": "u64"
+          },
+          {
+            "name": "exp",
+            "type": "i8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "VerificationLevel",
+      "docs": [
+        "Pyth price updates are bridged to all blockchains via Wormhole.",
+        "Using the price updates on another chain requires verifying the signatures of the Wormhole guardians.",
+        "The usual process is to check the signatures for two thirds of the total number of guardians, but this can be cumbersome on Solana because of the transaction size limits,",
+        "so we also allow for partial verification.",
+        "",
+        "This enum represents how much a price update has been verified:",
+        "- If `Full`, we have verified the signatures for two thirds of the current guardians.",
+        "- If `Partial`, only `num_signatures` guardian signatures have been checked.",
+        "",
+        "# Warning",
+        "Using partially verified price updates is dangerous, as it lowers the threshold of guardians that need to collude to produce a malicious price update."
+      ],
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Partial",
+            "fields": [
+              {
+                "name": "num_signatures",
+                "type": "u8"
+              }
+            ]
+          },
+          {
+            "name": "Full"
+          }
+        ]
+      }
+    },
+    {
+      "name": "VirtualStablecoin",
+      "docs": [
+        "Simple counter representing the supply of a \"virtual\" stablecoin."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "supply",
+            "type": {
+              "defined": {
+                "name": "UFixValue64"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "YieldHarvestConfig",
+      "docs": [
+        "Captures yield harvest configuration as two basis point values:"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "allocation",
+            "type": {
+              "defined": {
+                "name": "UFixValue64"
+              }
+            }
+          },
+          {
+            "name": "fee",
+            "type": {
+              "defined": {
+                "name": "UFixValue64"
+              }
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "constants": [
+    {
+      "name": "EXECUTOR_TIP_LAMPORTS",
+      "docs": [
+        "Flat SOL tip paid to the executor on successful `execute_order_*`.",
+        "",
+        "Owner deposits this into the order PDA at `create_order_*` time (in",
+        "addition to the rent-exempt minimum). Executor receives these lamports",
+        "on successful execute. Cancel refunds the unused tip to the owner via",
+        "Anchor's `close = owner` on the order PDA.",
+        "",
+        "Sized to cover the executor's worst-case outlay (~0.00203 SOL ATA",
+        "donation + tx fee) with ~2.5x margin."
+      ],
+      "type": "u64",
+      "value": "5000000"
+    },
+    {
+      "name": "ORDER",
+      "docs": [
+        "Seed for `TriggerOrder` PDAs."
+      ],
+      "type": {
+        "array": [
+          "u8",
+          5
+        ]
+      },
+      "value": "[111, 114, 100, 101, 114]"
+    }
+  ]
+}

--- a/hylo-idl/idls/hylo_trigger_orders_shadow.json
+++ b/hylo-idl/idls/hylo_trigger_orders_shadow.json
@@ -5492,18 +5492,6 @@
           {
             "name": "bump",
             "type": "u8"
-          },
-          {
-            "name": "_reserved",
-            "docs": [
-              "Reserved for forward-compatible field additions without a migration."
-            ],
-            "type": {
-              "array": [
-                "u8",
-                64
-              ]
-            }
           }
         ]
       }

--- a/hylo-idl/idls/hylo_trigger_orders_shadow.json
+++ b/hylo-idl/idls/hylo_trigger_orders_shadow.json
@@ -8,16 +8,16 @@
   },
   "instructions": [
     {
-      "name": "cancel_order_l2s_exo",
+      "name": "cancel_order_lever_to_stable_exo",
       "discriminator": [
-        61,
-        165,
-        75,
-        198,
-        91,
-        170,
-        235,
-        153
+        47,
+        127,
+        17,
+        226,
+        125,
+        19,
+        22,
+        80
       ],
       "accounts": [
         {
@@ -239,21 +239,21 @@
       "args": [],
       "returns": {
         "defined": {
-          "name": "TriggerOrderCancelled"
+          "name": "TriggerOrderCancelledEvent"
         }
       }
     },
     {
-      "name": "cancel_order_l2s_lst",
+      "name": "cancel_order_lever_to_stable_lst",
       "discriminator": [
-        121,
-        201,
-        137,
-        113,
-        147,
-        216,
-        109,
-        177
+        68,
+        60,
+        120,
+        236,
+        126,
+        232,
+        1,
+        22
       ],
       "accounts": [
         {
@@ -455,21 +455,21 @@
       "args": [],
       "returns": {
         "defined": {
-          "name": "TriggerOrderCancelled"
+          "name": "TriggerOrderCancelledEvent"
         }
       }
     },
     {
-      "name": "cancel_order_s2l",
+      "name": "cancel_order_stable_to_lever",
       "discriminator": [
-        85,
-        20,
-        75,
-        12,
-        198,
-        159,
-        196,
-        50
+        45,
+        2,
+        38,
+        191,
+        74,
+        153,
+        31,
+        179
       ],
       "accounts": [
         {
@@ -672,21 +672,21 @@
       "args": [],
       "returns": {
         "defined": {
-          "name": "TriggerOrderCancelled"
+          "name": "TriggerOrderCancelledEvent"
         }
       }
     },
     {
-      "name": "create_order_l2s_exo",
+      "name": "create_order_lever_to_stable_exo",
       "discriminator": [
-        145,
-        7,
-        163,
-        2,
-        20,
-        124,
-        128,
-        146
+        18,
+        5,
+        47,
+        137,
+        57,
+        87,
+        9,
+        108
       ],
       "accounts": [
         {
@@ -923,8 +923,9 @@
             "above), so a malformed mint creates a PDA at an address unique to that",
             "owner/nonce/mint triple. No collision risk with other orders.",
             "2. Only the owner is harmed by an unfillable order — their levercoin goes",
-            "into a PDA they alone can drain via `cancel_order_l2s_exo`. There's no",
-            "path for an attacker to lock anyone else's funds via this vector.",
+            "into a PDA they alone can drain via",
+            "`cancel_order_lever_to_stable_exo`. There's no path for an attacker to",
+            "lock anyone else's funds via this vector.",
             "3. The cancel path doesn't read `ExoPair`, `Hylo`, or any pair-specific",
             "state. So even if Hylo deprecates this collateral, the owner can",
             "always recover. Funds-recoverability is structural, not policy.",
@@ -1011,21 +1012,21 @@
       ],
       "returns": {
         "defined": {
-          "name": "TriggerOrderCreated"
+          "name": "TriggerOrderCreatedEvent"
         }
       }
     },
     {
-      "name": "create_order_l2s_lst",
+      "name": "create_order_lever_to_stable_lst",
       "discriminator": [
-        217,
-        157,
-        106,
-        121,
-        230,
-        232,
-        238,
-        73
+        169,
+        244,
+        48,
+        59,
+        91,
+        86,
+        47,
+        4
       ],
       "accounts": [
         {
@@ -1295,21 +1296,21 @@
       ],
       "returns": {
         "defined": {
-          "name": "TriggerOrderCreated"
+          "name": "TriggerOrderCreatedEvent"
         }
       }
     },
     {
-      "name": "create_order_s2l_exo",
+      "name": "create_order_stable_to_lever_exo",
       "discriminator": [
+        64,
+        253,
+        226,
+        234,
         102,
-        197,
-        120,
-        21,
-        57,
-        139,
-        195,
-        202
+        182,
+        158,
+        44
       ],
       "accounts": [
         {
@@ -1534,8 +1535,9 @@
             "above), so a malformed mint creates a PDA at an address unique to that",
             "owner/nonce/mint triple. No collision risk with other orders.",
             "2. Only the owner is harmed by an unfillable order — their HYUSD goes",
-            "into a PDA they alone can drain via `cancel_order_s2l`. There's no",
-            "path for an attacker to lock anyone else's funds via this vector.",
+            "into a PDA they alone can drain via `cancel_order_stable_to_lever`.",
+            "There's no path for an attacker to lock anyone else's funds via this",
+            "vector.",
             "3. The cancel path doesn't read `ExoPair`, `Hylo`, or any pair-specific",
             "state. So even if Hylo deprecates this collateral, the owner can",
             "always recover. Funds-recoverability is structural, not policy.",
@@ -1622,21 +1624,21 @@
       ],
       "returns": {
         "defined": {
-          "name": "TriggerOrderCreated"
+          "name": "TriggerOrderCreatedEvent"
         }
       }
     },
     {
-      "name": "create_order_s2l_lst",
+      "name": "create_order_stable_to_lever_lst",
       "discriminator": [
-        1,
-        195,
-        39,
-        158,
-        147,
-        192,
-        10,
-        101
+        44,
+        239,
+        230,
+        43,
+        167,
+        109,
+        159,
+        75
       ],
       "accounts": [
         {
@@ -1907,21 +1909,21 @@
       ],
       "returns": {
         "defined": {
-          "name": "TriggerOrderCreated"
+          "name": "TriggerOrderCreatedEvent"
         }
       }
     },
     {
-      "name": "execute_order_l2s_exo",
+      "name": "execute_order_lever_to_stable_exo",
       "discriminator": [
-        112,
-        175,
-        205,
-        216,
-        129,
-        95,
-        184,
-        153
+        37,
+        208,
+        145,
+        18,
+        1,
+        120,
+        209,
+        189
       ],
       "accounts": [
         {
@@ -2606,21 +2608,21 @@
       "args": [],
       "returns": {
         "defined": {
-          "name": "TriggerOrderFilled"
+          "name": "TriggerOrderFilledEvent"
         }
       }
     },
     {
-      "name": "execute_order_l2s_lst",
+      "name": "execute_order_lever_to_stable_lst",
       "discriminator": [
-        96,
-        37,
-        224,
-        31,
-        190,
-        139,
-        223,
-        0
+        148,
+        194,
+        232,
+        208,
+        165,
+        164,
+        221,
+        71
       ],
       "accounts": [
         {
@@ -3079,21 +3081,21 @@
       "args": [],
       "returns": {
         "defined": {
-          "name": "TriggerOrderFilled"
+          "name": "TriggerOrderFilledEvent"
         }
       }
     },
     {
-      "name": "execute_order_s2l_exo",
+      "name": "execute_order_stable_to_lever_exo",
       "discriminator": [
-        29,
-        184,
-        147,
-        164,
-        106,
-        9,
-        121,
-        21
+        78,
+        24,
+        242,
+        4,
+        17,
+        60,
+        133,
+        89
       ],
       "accounts": [
         {
@@ -3778,21 +3780,21 @@
       "args": [],
       "returns": {
         "defined": {
-          "name": "TriggerOrderFilled"
+          "name": "TriggerOrderFilledEvent"
         }
       }
     },
     {
-      "name": "execute_order_s2l_lst",
+      "name": "execute_order_stable_to_lever_lst",
       "discriminator": [
-        26,
-        104,
-        100,
-        203,
-        82,
-        5,
-        112,
-        58
+        225,
+        97,
+        249,
+        74,
+        99,
+        214,
+        130,
+        114
       ],
       "accounts": [
         {
@@ -4251,7 +4253,7 @@
       "args": [],
       "returns": {
         "defined": {
-          "name": "TriggerOrderFilled"
+          "name": "TriggerOrderFilledEvent"
         }
       }
     }
@@ -4312,42 +4314,42 @@
   ],
   "events": [
     {
-      "name": "TriggerOrderCancelled",
+      "name": "TriggerOrderCancelledEvent",
       "discriminator": [
-        255,
-        151,
-        206,
-        140,
-        98,
-        153,
-        223,
-        121
-      ]
-    },
-    {
-      "name": "TriggerOrderCreated",
-      "discriminator": [
-        90,
-        78,
+        178,
+        127,
         39,
-        34,
-        130,
-        168,
-        79,
-        55
+        234,
+        87,
+        193,
+        7,
+        119
       ]
     },
     {
-      "name": "TriggerOrderFilled",
+      "name": "TriggerOrderCreatedEvent",
       "discriminator": [
-        124,
-        156,
-        201,
-        86,
-        158,
-        86,
-        183,
-        212
+        231,
+        191,
+        133,
+        0,
+        130,
+        0,
+        198,
+        83
+      ]
+    },
+    {
+      "name": "TriggerOrderFilledEvent",
+      "discriminator": [
+        72,
+        131,
+        117,
+        214,
+        75,
+        219,
+        32,
+        36
       ]
     }
   ],
@@ -4355,27 +4357,27 @@
     {
       "code": 6000,
       "name": "AmountTooSmall",
-      "msg": "escrow_amount must be > 0"
+      "msg": "Escrow amount must be greater than zero."
     },
     {
       "code": 6001,
       "name": "AccountMismatch",
-      "msg": "account does not match the order's pair target"
+      "msg": "Account does not match the order's pair target."
     },
     {
       "code": 6002,
       "name": "TriggerNotMet",
-      "msg": "price condition not met"
+      "msg": "Price condition not met."
     },
     {
       "code": 6003,
       "name": "Unauthorized",
-      "msg": "signer is not the order owner"
+      "msg": "Signer is not the order owner."
     },
     {
       "code": 6004,
       "name": "InvalidPythPrice",
-      "msg": "invalid pyth price update account, feed id, or expo"
+      "msg": "Invalid Pyth price update account, feed id, or exponent."
     }
   ],
   "types": [
@@ -5125,7 +5127,8 @@
           {
             "name": "convert_direction",
             "docs": [
-              "Direction of the Hylo convert ix this order will fire (s2l or l2s)."
+              "Direction of the Hylo convert ix this order will fire",
+              "(`stable_to_lever` or `lever_to_stable`)."
             ],
             "type": {
               "defined": {
@@ -5145,7 +5148,8 @@
             "name": "escrow_amount",
             "docs": [
               "Amount escrowed in the order's escrow vault. Unit depends on",
-              "`convert_direction`: HYUSD for s2l; xSOL or per-EXO levercoin for l2s."
+              "`convert_direction`: HYUSD for `stable_to_lever`; xSOL or per-EXO",
+              "levercoin for `lever_to_stable`."
             ],
             "type": "u64"
           },
@@ -5181,15 +5185,26 @@
           {
             "name": "bump",
             "type": "u8"
+          },
+          {
+            "name": "_reserved",
+            "docs": [
+              "Reserved for forward-compatible field additions without a migration."
+            ],
+            "type": {
+              "array": [
+                "u8",
+                64
+              ]
+            }
           }
         ]
       }
     },
     {
-      "name": "TriggerOrderCancelled",
+      "name": "TriggerOrderCancelledEvent",
       "docs": [
-        "Emitted at the end of `cancel_order_{s2l,l2s_lst,l2s_exo}` after the",
-        "refund completes."
+        "Emitted at the end of `cancel_order_*` after the refund completes."
       ],
       "type": {
         "kind": "struct",
@@ -5230,10 +5245,9 @@
       }
     },
     {
-      "name": "TriggerOrderCreated",
+      "name": "TriggerOrderCreatedEvent",
       "docs": [
-        "Emitted at the end of `create_order_{s2l,l2s}_{lst,exo}` after state",
-        "mutations succeed."
+        "Emitted at the end of `create_order_*` after state mutations succeed."
       ],
       "type": {
         "kind": "struct",
@@ -5269,7 +5283,8 @@
           {
             "name": "escrow_amount",
             "docs": [
-              "Amount escrowed (HYUSD for s2l, levercoin for l2s)."
+              "Amount escrowed (HYUSD for `stable_to_lever`, levercoin for",
+              "`lever_to_stable`)."
             ],
             "type": "u64"
           },
@@ -5297,11 +5312,11 @@
       }
     },
     {
-      "name": "TriggerOrderFilled",
+      "name": "TriggerOrderFilledEvent",
       "docs": [
-        "Emitted at the end of `execute_order_{s2l,l2s}_{lst,exo}` after the order",
-        "fills. `output_received` mirrors Hylo's convert event field",
-        "(`UFixValue64`) verbatim."
+        "Emitted at the end of `execute_order_*` after the order fills.",
+        "`output_received` mirrors Hylo's convert event field (`UFixValue64`)",
+        "verbatim."
       ],
       "type": {
         "kind": "struct",
@@ -5348,8 +5363,8 @@
           {
             "name": "output_received",
             "docs": [
-              "Amount minted to the owner's output ATA (levercoin for s2l, HYUSD for",
-              "l2s)."
+              "Amount minted to the owner's output ATA (levercoin for",
+              "`stable_to_lever`, HYUSD for `lever_to_stable`)."
             ],
             "type": {
               "defined": {
@@ -5360,7 +5375,8 @@
           {
             "name": "output_mint",
             "docs": [
-              "Mint of the output token (levercoin mint for s2l, HYUSD mint for l2s)."
+              "Mint of the output token (levercoin mint for `stable_to_lever`, HYUSD",
+              "mint for `lever_to_stable`)."
             ],
             "type": "pubkey"
           },

--- a/hylo-idl/idls/hylo_trigger_orders_shadow.json
+++ b/hylo-idl/idls/hylo_trigger_orders_shadow.json
@@ -1940,7 +1940,6 @@
         },
         {
           "name": "hylo",
-          "writable": true,
           "pda": {
             "seeds": [
               {
@@ -3263,7 +3262,6 @@
         },
         {
           "name": "hylo",
-          "writable": true,
           "pda": {
             "seeds": [
               {

--- a/hylo-idl/idls/hylo_trigger_orders_shadow.json
+++ b/hylo-idl/idls/hylo_trigger_orders_shadow.json
@@ -1939,7 +1939,58 @@
           ]
         },
         {
-          "name": "hylo"
+          "name": "hylo",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  104,
+                  121,
+                  108,
+                  111
+                ]
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                245,
+                187,
+                72,
+                160,
+                4,
+                116,
+                48,
+                134,
+                197,
+                164,
+                152,
+                189,
+                233,
+                219,
+                27,
+                124,
+                201,
+                65,
+                103,
+                243,
+                58,
+                82,
+                140,
+                90,
+                13,
+                150,
+                83,
+                40,
+                223,
+                158,
+                124,
+                33
+              ]
+            }
+          }
         },
         {
           "name": "exo_pair",
@@ -2639,7 +2690,57 @@
         },
         {
           "name": "hylo",
-          "writable": true
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  104,
+                  121,
+                  108,
+                  111
+                ]
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                245,
+                187,
+                72,
+                160,
+                4,
+                116,
+                48,
+                134,
+                197,
+                164,
+                152,
+                189,
+                233,
+                219,
+                27,
+                124,
+                201,
+                65,
+                103,
+                243,
+                58,
+                82,
+                140,
+                90,
+                13,
+                150,
+                83,
+                40,
+                223,
+                158,
+                124,
+                33
+              ]
+            }
+          }
         },
         {
           "name": "sol_usd_pyth_feed"
@@ -2711,7 +2812,57 @@
         },
         {
           "name": "xsol_mint",
-          "writable": true
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  120,
+                  83,
+                  79,
+                  76
+                ]
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                245,
+                187,
+                72,
+                160,
+                4,
+                116,
+                48,
+                134,
+                197,
+                164,
+                152,
+                189,
+                233,
+                219,
+                27,
+                124,
+                201,
+                65,
+                103,
+                243,
+                58,
+                82,
+                140,
+                90,
+                13,
+                150,
+                83,
+                40,
+                223,
+                158,
+                124,
+                33
+              ]
+            }
+          }
         },
         {
           "name": "levercoin_auth"
@@ -3111,7 +3262,58 @@
           ]
         },
         {
-          "name": "hylo"
+          "name": "hylo",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  104,
+                  121,
+                  108,
+                  111
+                ]
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                245,
+                187,
+                72,
+                160,
+                4,
+                116,
+                48,
+                134,
+                197,
+                164,
+                152,
+                189,
+                233,
+                219,
+                27,
+                124,
+                201,
+                65,
+                103,
+                243,
+                58,
+                82,
+                140,
+                90,
+                13,
+                150,
+                83,
+                40,
+                223,
+                158,
+                124,
+                33
+              ]
+            }
+          }
         },
         {
           "name": "exo_pair",
@@ -3811,7 +4013,57 @@
         },
         {
           "name": "hylo",
-          "writable": true
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  104,
+                  121,
+                  108,
+                  111
+                ]
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                245,
+                187,
+                72,
+                160,
+                4,
+                116,
+                48,
+                134,
+                197,
+                164,
+                152,
+                189,
+                233,
+                219,
+                27,
+                124,
+                201,
+                65,
+                103,
+                243,
+                58,
+                82,
+                140,
+                90,
+                13,
+                150,
+                83,
+                40,
+                223,
+                158,
+                124,
+                33
+              ]
+            }
+          }
         },
         {
           "name": "sol_usd_pyth_feed"
@@ -3883,7 +4135,57 @@
         },
         {
           "name": "xsol_mint",
-          "writable": true
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  120,
+                  83,
+                  79,
+                  76
+                ]
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                245,
+                187,
+                72,
+                160,
+                4,
+                116,
+                48,
+                134,
+                197,
+                164,
+                152,
+                189,
+                233,
+                219,
+                27,
+                124,
+                201,
+                65,
+                103,
+                243,
+                58,
+                82,
+                140,
+                90,
+                13,
+                150,
+                83,
+                40,
+                223,
+                158,
+                124,
+                33
+              ]
+            }
+          }
         },
         {
           "name": "levercoin_auth"
@@ -4378,6 +4680,11 @@
       "code": 6004,
       "name": "InvalidPythPrice",
       "msg": "Invalid Pyth price update account, feed id, or exponent."
+    },
+    {
+      "code": 6005,
+      "name": "TipArithmetic",
+      "msg": "Executor tip arithmetic overflowed the order's lamport balance."
     }
   ],
   "types": [
@@ -4412,8 +4719,8 @@
       "name": "ConvertDirection",
       "docs": [
         "Direction of the underlying Hylo convert ix the trigger order will fire.",
-        "`StableToLever` burns HYUSD to mint levercoin (the v1 direction).",
-        "`LeverToStable` burns levercoin to mint HYUSD (v1.1 addition)."
+        "`StableToLever` burns HYUSD to mint levercoin; `LeverToStable` burns",
+        "levercoin to mint HYUSD."
       ],
       "type": {
         "kind": "enum",

--- a/hylo-idl/src/account_builders/mod.rs
+++ b/hylo-idl/src/account_builders/mod.rs
@@ -1,2 +1,3 @@
 pub mod earn_pool;
 pub mod exchange;
+pub mod trigger_orders;

--- a/hylo-idl/src/account_builders/trigger_orders.rs
+++ b/hylo-idl/src/account_builders/trigger_orders.rs
@@ -1,0 +1,181 @@
+//! Account-context builders for `hylo-trigger-orders`.
+
+use anchor_lang::prelude::Pubkey;
+use anchor_lang::solana_program::sysvar::rent;
+use anchor_lang::system_program;
+use anchor_spl::{associated_token, token};
+
+use crate::tokens::{TokenMint, HYUSD, XSOL};
+use crate::trigger_orders::client::accounts::{
+  CreateOrderL2sExo, CreateOrderL2sLst, CreateOrderS2lExo, CreateOrderS2lLst,
+};
+use crate::{pda, trigger_orders};
+
+/// Builds account context for creating a stable-to-lever order (LST).
+#[must_use]
+pub fn create_order_s2l_lst(owner: Pubkey, order: Pubkey) -> CreateOrderS2lLst {
+  CreateOrderS2lLst {
+    owner,
+    order,
+    order_hyusd_vault: pda::ata(order, HYUSD::MINT),
+    owner_hyusd_ta: pda::ata(owner, HYUSD::MINT),
+    hyusd_mint: HYUSD::MINT,
+    event_authority: pda::trigger_orders_event_authority(),
+    program: trigger_orders::ID,
+    token_program: token::ID,
+    associated_token_program: associated_token::ID,
+    system_program: system_program::ID,
+    rent: rent::ID,
+  }
+}
+
+/// Builds account context for creating a stable-to-lever order (EXO).
+#[must_use]
+pub fn create_order_s2l_exo(
+  owner: Pubkey,
+  order: Pubkey,
+  collateral_mint: Pubkey,
+) -> CreateOrderS2lExo {
+  CreateOrderS2lExo {
+    owner,
+    order,
+    order_hyusd_vault: pda::ata(order, HYUSD::MINT),
+    owner_hyusd_ta: pda::ata(owner, HYUSD::MINT),
+    hyusd_mint: HYUSD::MINT,
+    collateral_mint,
+    event_authority: pda::trigger_orders_event_authority(),
+    program: trigger_orders::ID,
+    token_program: token::ID,
+    associated_token_program: associated_token::ID,
+    system_program: system_program::ID,
+    rent: rent::ID,
+  }
+}
+
+/// Builds account context for creating a lever-to-stable order (LST).
+#[must_use]
+pub fn create_order_l2s_lst(owner: Pubkey, order: Pubkey) -> CreateOrderL2sLst {
+  CreateOrderL2sLst {
+    owner,
+    order,
+    order_xsol_vault: pda::ata(order, XSOL::MINT),
+    owner_xsol_ta: pda::ata(owner, XSOL::MINT),
+    xsol_mint: XSOL::MINT,
+    event_authority: pda::trigger_orders_event_authority(),
+    program: trigger_orders::ID,
+    token_program: token::ID,
+    associated_token_program: associated_token::ID,
+    system_program: system_program::ID,
+    rent: rent::ID,
+  }
+}
+
+/// Builds account context for creating a lever-to-stable order (EXO).
+#[must_use]
+pub fn create_order_l2s_exo(
+  owner: Pubkey,
+  order: Pubkey,
+  collateral_mint: Pubkey,
+) -> CreateOrderL2sExo {
+  let levercoin_mint = pda::exo_levercoin_mint(collateral_mint);
+  CreateOrderL2sExo {
+    owner,
+    order,
+    order_levercoin_vault: pda::ata(order, levercoin_mint),
+    owner_levercoin_ta: pda::ata(owner, levercoin_mint),
+    levercoin_mint,
+    collateral_mint,
+    event_authority: pda::trigger_orders_event_authority(),
+    program: trigger_orders::ID,
+    token_program: token::ID,
+    associated_token_program: associated_token::ID,
+    system_program: system_program::ID,
+    rent: rent::ID,
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn create_order_s2l_lst_builds_correct_pdas() {
+    let owner = Pubkey::new_unique();
+    let order = Pubkey::new_unique();
+    let a = create_order_s2l_lst(owner, order);
+
+    assert_eq!(a.owner, owner);
+    assert_eq!(a.order, order);
+    assert_eq!(a.hyusd_mint, HYUSD::MINT);
+    assert_eq!(a.order_hyusd_vault, pda::ata(order, HYUSD::MINT));
+    assert_eq!(a.owner_hyusd_ta, pda::ata(owner, HYUSD::MINT));
+    assert_eq!(a.event_authority, pda::trigger_orders_event_authority());
+    assert_eq!(a.program, trigger_orders::ID);
+    assert_eq!(a.token_program, token::ID);
+    assert_eq!(a.associated_token_program, associated_token::ID);
+    assert_eq!(a.system_program, system_program::ID);
+    assert_eq!(a.rent, rent::ID);
+  }
+
+  #[test]
+  fn create_order_s2l_exo_builds_correct_pdas() {
+    let owner = Pubkey::new_unique();
+    let order = Pubkey::new_unique();
+    let collateral_mint = Pubkey::new_unique();
+    let a = create_order_s2l_exo(owner, order, collateral_mint);
+
+    assert_eq!(a.owner, owner);
+    assert_eq!(a.order, order);
+    assert_eq!(a.hyusd_mint, HYUSD::MINT);
+    assert_eq!(a.order_hyusd_vault, pda::ata(order, HYUSD::MINT));
+    assert_eq!(a.owner_hyusd_ta, pda::ata(owner, HYUSD::MINT));
+    assert_eq!(a.collateral_mint, collateral_mint);
+    assert_eq!(a.event_authority, pda::trigger_orders_event_authority());
+    assert_eq!(a.program, trigger_orders::ID);
+    assert_eq!(a.token_program, token::ID);
+    assert_eq!(a.associated_token_program, associated_token::ID);
+    assert_eq!(a.system_program, system_program::ID);
+    assert_eq!(a.rent, rent::ID);
+  }
+
+  #[test]
+  fn create_order_l2s_lst_builds_correct_pdas() {
+    let owner = Pubkey::new_unique();
+    let order = Pubkey::new_unique();
+    let a = create_order_l2s_lst(owner, order);
+
+    assert_eq!(a.owner, owner);
+    assert_eq!(a.order, order);
+    assert_eq!(a.xsol_mint, XSOL::MINT);
+    assert_eq!(a.order_xsol_vault, pda::ata(order, XSOL::MINT));
+    assert_eq!(a.owner_xsol_ta, pda::ata(owner, XSOL::MINT));
+    assert_eq!(a.event_authority, pda::trigger_orders_event_authority());
+    assert_eq!(a.program, trigger_orders::ID);
+    assert_eq!(a.token_program, token::ID);
+    assert_eq!(a.associated_token_program, associated_token::ID);
+    assert_eq!(a.system_program, system_program::ID);
+    assert_eq!(a.rent, rent::ID);
+  }
+
+  #[test]
+  fn create_order_l2s_exo_builds_correct_pdas() {
+    let owner = Pubkey::new_unique();
+    let order = Pubkey::new_unique();
+    let collateral_mint = Pubkey::new_unique();
+    let levercoin_mint = pda::exo_levercoin_mint(collateral_mint);
+    let a = create_order_l2s_exo(owner, order, collateral_mint);
+
+    assert_eq!(a.owner, owner);
+    assert_eq!(a.order, order);
+    assert_eq!(a.levercoin_mint, levercoin_mint);
+    assert_eq!(a.order_levercoin_vault, pda::ata(order, levercoin_mint));
+    assert_eq!(a.owner_levercoin_ta, pda::ata(owner, levercoin_mint));
+    assert_eq!(a.collateral_mint, collateral_mint);
+    assert_eq!(a.event_authority, pda::trigger_orders_event_authority());
+    assert_eq!(a.program, trigger_orders::ID);
+    assert_eq!(a.token_program, token::ID);
+    assert_eq!(a.associated_token_program, associated_token::ID);
+    assert_eq!(a.system_program, system_program::ID);
+    assert_eq!(a.rent, rent::ID);
+  }
+}

--- a/hylo-idl/src/account_builders/trigger_orders.rs
+++ b/hylo-idl/src/account_builders/trigger_orders.rs
@@ -8,16 +8,22 @@ use anchor_spl::{associated_token, token};
 use crate::exchange::accounts::{ExoPair, Hylo};
 use crate::tokens::{TokenMint, HYUSD, XSOL};
 use crate::trigger_orders::client::accounts::{
-  CancelOrderL2sExo, CancelOrderL2sLst, CancelOrderS2l, CreateOrderL2sExo,
-  CreateOrderL2sLst, CreateOrderS2lExo, CreateOrderS2lLst, ExecuteOrderL2sExo,
-  ExecuteOrderL2sLst, ExecuteOrderS2lExo, ExecuteOrderS2lLst,
+  CancelOrderLeverToStableExo, CancelOrderLeverToStableLst,
+  CancelOrderStableToLever, CreateOrderLeverToStableExo,
+  CreateOrderLeverToStableLst, CreateOrderStableToLeverExo,
+  CreateOrderStableToLeverLst, ExecuteOrderLeverToStableExo,
+  ExecuteOrderLeverToStableLst, ExecuteOrderStableToLeverExo,
+  ExecuteOrderStableToLeverLst,
 };
 use crate::{pda, trigger_orders};
 
 /// Builds account context for creating a stable-to-lever order (LST).
 #[must_use]
-pub fn create_order_s2l_lst(owner: Pubkey, order: Pubkey) -> CreateOrderS2lLst {
-  CreateOrderS2lLst {
+pub fn create_order_stable_to_lever_lst(
+  owner: Pubkey,
+  order: Pubkey,
+) -> CreateOrderStableToLeverLst {
+  CreateOrderStableToLeverLst {
     owner,
     order,
     order_hyusd_vault: pda::ata(order, HYUSD::MINT),
@@ -34,12 +40,12 @@ pub fn create_order_s2l_lst(owner: Pubkey, order: Pubkey) -> CreateOrderS2lLst {
 
 /// Builds account context for creating a stable-to-lever order (EXO).
 #[must_use]
-pub fn create_order_s2l_exo(
+pub fn create_order_stable_to_lever_exo(
   owner: Pubkey,
   order: Pubkey,
   collateral_mint: Pubkey,
-) -> CreateOrderS2lExo {
-  CreateOrderS2lExo {
+) -> CreateOrderStableToLeverExo {
+  CreateOrderStableToLeverExo {
     owner,
     order,
     order_hyusd_vault: pda::ata(order, HYUSD::MINT),
@@ -57,8 +63,11 @@ pub fn create_order_s2l_exo(
 
 /// Builds account context for creating a lever-to-stable order (LST).
 #[must_use]
-pub fn create_order_l2s_lst(owner: Pubkey, order: Pubkey) -> CreateOrderL2sLst {
-  CreateOrderL2sLst {
+pub fn create_order_lever_to_stable_lst(
+  owner: Pubkey,
+  order: Pubkey,
+) -> CreateOrderLeverToStableLst {
+  CreateOrderLeverToStableLst {
     owner,
     order,
     order_xsol_vault: pda::ata(order, XSOL::MINT),
@@ -75,13 +84,13 @@ pub fn create_order_l2s_lst(owner: Pubkey, order: Pubkey) -> CreateOrderL2sLst {
 
 /// Builds account context for creating a lever-to-stable order (EXO).
 #[must_use]
-pub fn create_order_l2s_exo(
+pub fn create_order_lever_to_stable_exo(
   owner: Pubkey,
   order: Pubkey,
   collateral_mint: Pubkey,
-) -> CreateOrderL2sExo {
+) -> CreateOrderLeverToStableExo {
   let levercoin_mint = pda::exo_levercoin_mint(collateral_mint);
-  CreateOrderL2sExo {
+  CreateOrderLeverToStableExo {
     owner,
     order,
     order_levercoin_vault: pda::ata(order, levercoin_mint),
@@ -99,13 +108,13 @@ pub fn create_order_l2s_exo(
 
 /// Builds account context for executing a stable-to-lever order (LST).
 #[must_use]
-pub fn execute_order_s2l_lst(
+pub fn execute_order_stable_to_lever_lst(
   executor: Pubkey,
   owner: Pubkey,
   order: Pubkey,
   hylo: &Hylo,
-) -> ExecuteOrderS2lLst {
-  ExecuteOrderS2lLst {
+) -> ExecuteOrderStableToLeverLst {
+  ExecuteOrderStableToLeverLst {
     executor,
     owner,
     hylo: pda::HYLO,
@@ -132,13 +141,13 @@ pub fn execute_order_s2l_lst(
 
 /// Builds account context for executing a lever-to-stable order (LST).
 #[must_use]
-pub fn execute_order_l2s_lst(
+pub fn execute_order_lever_to_stable_lst(
   executor: Pubkey,
   owner: Pubkey,
   order: Pubkey,
   hylo: &Hylo,
-) -> ExecuteOrderL2sLst {
-  ExecuteOrderL2sLst {
+) -> ExecuteOrderLeverToStableLst {
+  ExecuteOrderLeverToStableLst {
     executor,
     owner,
     hylo: pda::HYLO,
@@ -168,17 +177,17 @@ pub fn execute_order_l2s_lst(
 /// `_hylo` is accepted for signature symmetry with the LST builders; the EXO
 /// CPI uses the per-pair `exo_pair.oracle` rather than the Hylo SOL/USD oracle.
 #[must_use]
-pub fn execute_order_s2l_exo(
+pub fn execute_order_stable_to_lever_exo(
   executor: Pubkey,
   owner: Pubkey,
   order: Pubkey,
   collateral_mint: Pubkey,
   _hylo: &Hylo,
   exo_pair: &ExoPair,
-) -> ExecuteOrderS2lExo {
+) -> ExecuteOrderStableToLeverExo {
   let levercoin_mint = pda::exo_levercoin_mint(collateral_mint);
   let vault_auth = pda::exo_vault_auth(collateral_mint);
-  ExecuteOrderS2lExo {
+  ExecuteOrderStableToLeverExo {
     executor,
     owner,
     hylo: pda::HYLO,
@@ -212,17 +221,17 @@ pub fn execute_order_s2l_exo(
 /// `_hylo` is accepted for signature symmetry with the LST builders; the EXO
 /// CPI uses the per-pair `exo_pair.oracle` rather than the Hylo SOL/USD oracle.
 #[must_use]
-pub fn execute_order_l2s_exo(
+pub fn execute_order_lever_to_stable_exo(
   executor: Pubkey,
   owner: Pubkey,
   order: Pubkey,
   collateral_mint: Pubkey,
   _hylo: &Hylo,
   exo_pair: &ExoPair,
-) -> ExecuteOrderL2sExo {
+) -> ExecuteOrderLeverToStableExo {
   let levercoin_mint = pda::exo_levercoin_mint(collateral_mint);
   let vault_auth = pda::exo_vault_auth(collateral_mint);
-  ExecuteOrderL2sExo {
+  ExecuteOrderLeverToStableExo {
     executor,
     owner,
     hylo: pda::HYLO,
@@ -253,11 +262,15 @@ pub fn execute_order_l2s_exo(
 
 /// Builds account context for cancelling a stable-to-lever order.
 ///
-/// Handles both LST and EXO s2l orders: the s2l escrow is always HYUSD
-/// regardless of the order's lever target, so no collateral mint is needed.
+/// Handles both LST and EXO stable-to-lever orders: the stable-to-lever
+/// escrow is always HYUSD regardless of the order's lever target, so no
+/// collateral mint is needed.
 #[must_use]
-pub fn cancel_order_s2l(owner: Pubkey, order: Pubkey) -> CancelOrderS2l {
-  CancelOrderS2l {
+pub fn cancel_order_stable_to_lever(
+  owner: Pubkey,
+  order: Pubkey,
+) -> CancelOrderStableToLever {
+  CancelOrderStableToLever {
     owner,
     order,
     order_hyusd_vault: pda::ata(order, HYUSD::MINT),
@@ -271,8 +284,11 @@ pub fn cancel_order_s2l(owner: Pubkey, order: Pubkey) -> CancelOrderS2l {
 
 /// Builds account context for cancelling a lever-to-stable order (LST).
 #[must_use]
-pub fn cancel_order_l2s_lst(owner: Pubkey, order: Pubkey) -> CancelOrderL2sLst {
-  CancelOrderL2sLst {
+pub fn cancel_order_lever_to_stable_lst(
+  owner: Pubkey,
+  order: Pubkey,
+) -> CancelOrderLeverToStableLst {
+  CancelOrderLeverToStableLst {
     owner,
     order,
     order_xsol_vault: pda::ata(order, XSOL::MINT),
@@ -286,13 +302,13 @@ pub fn cancel_order_l2s_lst(owner: Pubkey, order: Pubkey) -> CancelOrderL2sLst {
 
 /// Builds account context for cancelling a lever-to-stable order (EXO).
 #[must_use]
-pub fn cancel_order_l2s_exo(
+pub fn cancel_order_lever_to_stable_exo(
   owner: Pubkey,
   order: Pubkey,
   collateral_mint: Pubkey,
-) -> CancelOrderL2sExo {
+) -> CancelOrderLeverToStableExo {
   let levercoin_mint = pda::exo_levercoin_mint(collateral_mint);
-  CancelOrderL2sExo {
+  CancelOrderLeverToStableExo {
     owner,
     order,
     order_levercoin_vault: pda::ata(order, levercoin_mint),
@@ -347,7 +363,7 @@ mod tests {
   }
 
   #[test]
-  fn execute_order_s2l_lst_threads_hylo_oracle() {
+  fn execute_order_stable_to_lever_lst_threads_hylo_oracle() {
     let executor = Pubkey::new_unique();
     let owner = Pubkey::new_unique();
     let order = Pubkey::new_unique();
@@ -355,7 +371,7 @@ mod tests {
     let oracle = Pubkey::new_unique();
     hylo.sol_usd_oracle = oracle;
 
-    let a = execute_order_s2l_lst(executor, owner, order, &hylo);
+    let a = execute_order_stable_to_lever_lst(executor, owner, order, &hylo);
 
     assert_eq!(a.executor, executor);
     assert_eq!(a.owner, owner);
@@ -384,7 +400,7 @@ mod tests {
   }
 
   #[test]
-  fn execute_order_l2s_lst_threads_hylo_oracle() {
+  fn execute_order_lever_to_stable_lst_threads_hylo_oracle() {
     let executor = Pubkey::new_unique();
     let owner = Pubkey::new_unique();
     let order = Pubkey::new_unique();
@@ -392,7 +408,7 @@ mod tests {
     let oracle = Pubkey::new_unique();
     hylo.sol_usd_oracle = oracle;
 
-    let a = execute_order_l2s_lst(executor, owner, order, &hylo);
+    let a = execute_order_lever_to_stable_lst(executor, owner, order, &hylo);
 
     assert_eq!(a.executor, executor);
     assert_eq!(a.owner, owner);
@@ -421,7 +437,7 @@ mod tests {
   }
 
   #[test]
-  fn execute_order_s2l_exo_threads_exo_oracle() {
+  fn execute_order_stable_to_lever_exo_threads_exo_oracle() {
     let executor = Pubkey::new_unique();
     let owner = Pubkey::new_unique();
     let order = Pubkey::new_unique();
@@ -433,7 +449,7 @@ mod tests {
     let levercoin_mint = pda::exo_levercoin_mint(collateral_mint);
     let vault_auth = pda::exo_vault_auth(collateral_mint);
 
-    let a = execute_order_s2l_exo(
+    let a = execute_order_stable_to_lever_exo(
       executor,
       owner,
       order,
@@ -473,7 +489,7 @@ mod tests {
   }
 
   #[test]
-  fn execute_order_l2s_exo_threads_exo_oracle() {
+  fn execute_order_lever_to_stable_exo_threads_exo_oracle() {
     let executor = Pubkey::new_unique();
     let owner = Pubkey::new_unique();
     let order = Pubkey::new_unique();
@@ -485,7 +501,7 @@ mod tests {
     let levercoin_mint = pda::exo_levercoin_mint(collateral_mint);
     let vault_auth = pda::exo_vault_auth(collateral_mint);
 
-    let a = execute_order_l2s_exo(
+    let a = execute_order_lever_to_stable_exo(
       executor,
       owner,
       order,
@@ -525,10 +541,10 @@ mod tests {
   }
 
   #[test]
-  fn create_order_s2l_lst_builds_correct_pdas() {
+  fn create_order_stable_to_lever_lst_builds_correct_pdas() {
     let owner = Pubkey::new_unique();
     let order = Pubkey::new_unique();
-    let a = create_order_s2l_lst(owner, order);
+    let a = create_order_stable_to_lever_lst(owner, order);
 
     assert_eq!(a.owner, owner);
     assert_eq!(a.order, order);
@@ -544,11 +560,11 @@ mod tests {
   }
 
   #[test]
-  fn create_order_s2l_exo_builds_correct_pdas() {
+  fn create_order_stable_to_lever_exo_builds_correct_pdas() {
     let owner = Pubkey::new_unique();
     let order = Pubkey::new_unique();
     let collateral_mint = Pubkey::new_unique();
-    let a = create_order_s2l_exo(owner, order, collateral_mint);
+    let a = create_order_stable_to_lever_exo(owner, order, collateral_mint);
 
     assert_eq!(a.owner, owner);
     assert_eq!(a.order, order);
@@ -565,10 +581,10 @@ mod tests {
   }
 
   #[test]
-  fn create_order_l2s_lst_builds_correct_pdas() {
+  fn create_order_lever_to_stable_lst_builds_correct_pdas() {
     let owner = Pubkey::new_unique();
     let order = Pubkey::new_unique();
-    let a = create_order_l2s_lst(owner, order);
+    let a = create_order_lever_to_stable_lst(owner, order);
 
     assert_eq!(a.owner, owner);
     assert_eq!(a.order, order);
@@ -584,12 +600,12 @@ mod tests {
   }
 
   #[test]
-  fn create_order_l2s_exo_builds_correct_pdas() {
+  fn create_order_lever_to_stable_exo_builds_correct_pdas() {
     let owner = Pubkey::new_unique();
     let order = Pubkey::new_unique();
     let collateral_mint = Pubkey::new_unique();
     let levercoin_mint = pda::exo_levercoin_mint(collateral_mint);
-    let a = create_order_l2s_exo(owner, order, collateral_mint);
+    let a = create_order_lever_to_stable_exo(owner, order, collateral_mint);
 
     assert_eq!(a.owner, owner);
     assert_eq!(a.order, order);
@@ -606,10 +622,10 @@ mod tests {
   }
 
   #[test]
-  fn cancel_order_s2l_minimal_fields() {
+  fn cancel_order_stable_to_lever_minimal_fields() {
     let owner = Pubkey::new_unique();
     let order = Pubkey::new_unique();
-    let a = cancel_order_s2l(owner, order);
+    let a = cancel_order_stable_to_lever(owner, order);
     assert_eq!(a.owner, owner);
     assert_eq!(a.order, order);
     assert_eq!(a.order_hyusd_vault, pda::ata(order, HYUSD::MINT));
@@ -621,10 +637,10 @@ mod tests {
   }
 
   #[test]
-  fn cancel_order_l2s_lst_minimal_fields() {
+  fn cancel_order_lever_to_stable_lst_minimal_fields() {
     let owner = Pubkey::new_unique();
     let order = Pubkey::new_unique();
-    let a = cancel_order_l2s_lst(owner, order);
+    let a = cancel_order_lever_to_stable_lst(owner, order);
     assert_eq!(a.owner, owner);
     assert_eq!(a.order, order);
     assert_eq!(a.order_xsol_vault, pda::ata(order, XSOL::MINT));
@@ -636,12 +652,12 @@ mod tests {
   }
 
   #[test]
-  fn cancel_order_l2s_exo_minimal_fields() {
+  fn cancel_order_lever_to_stable_exo_minimal_fields() {
     let owner = Pubkey::new_unique();
     let order = Pubkey::new_unique();
     let collateral_mint = Pubkey::new_unique();
     let levercoin_mint = pda::exo_levercoin_mint(collateral_mint);
-    let a = cancel_order_l2s_exo(owner, order, collateral_mint);
+    let a = cancel_order_lever_to_stable_exo(owner, order, collateral_mint);
     assert_eq!(a.owner, owner);
     assert_eq!(a.order, order);
     assert_eq!(a.order_levercoin_vault, pda::ata(order, levercoin_mint));

--- a/hylo-idl/src/account_builders/trigger_orders.rs
+++ b/hylo-idl/src/account_builders/trigger_orders.rs
@@ -5,9 +5,12 @@ use anchor_lang::solana_program::sysvar::rent;
 use anchor_lang::system_program;
 use anchor_spl::{associated_token, token};
 
+use crate::exchange::accounts::{ExoPair, Hylo};
 use crate::tokens::{TokenMint, HYUSD, XSOL};
 use crate::trigger_orders::client::accounts::{
   CreateOrderL2sExo, CreateOrderL2sLst, CreateOrderS2lExo, CreateOrderS2lLst,
+  ExecuteOrderL2sExo, ExecuteOrderL2sLst, ExecuteOrderS2lExo,
+  ExecuteOrderS2lLst,
 };
 use crate::{pda, trigger_orders};
 
@@ -94,9 +97,378 @@ pub fn create_order_l2s_exo(
   }
 }
 
+/// Builds account context for executing a stable-to-lever order (LST).
+#[must_use]
+pub fn execute_order_s2l_lst(
+  executor: Pubkey,
+  owner: Pubkey,
+  order: Pubkey,
+  hylo: &Hylo,
+) -> ExecuteOrderS2lLst {
+  ExecuteOrderS2lLst {
+    executor,
+    owner,
+    hylo: pda::HYLO,
+    sol_usd_pyth_feed: hylo.sol_usd_oracle,
+    hyusd_mint: HYUSD::MINT,
+    stablecoin_auth: pda::HYUSD_AUTH,
+    fee_auth: pda::fee_auth(HYUSD::MINT),
+    fee_vault: pda::fee_vault(HYUSD::MINT),
+    xsol_mint: XSOL::MINT,
+    levercoin_auth: pda::XSOL_AUTH,
+    order,
+    order_hyusd_vault: pda::ata(order, HYUSD::MINT),
+    order_xsol_vault: pda::ata(order, XSOL::MINT),
+    owner_xsol_ta: pda::ata(owner, XSOL::MINT),
+    hylo_exchange_event_authority: pda::EXCHANGE_EVENT_AUTHORITY,
+    hylo_exchange_program: crate::exchange::ID,
+    event_authority: pda::trigger_orders_event_authority(),
+    program: trigger_orders::ID,
+    token_program: token::ID,
+    associated_token_program: associated_token::ID,
+    system_program: system_program::ID,
+  }
+}
+
+/// Builds account context for executing a lever-to-stable order (LST).
+#[must_use]
+pub fn execute_order_l2s_lst(
+  executor: Pubkey,
+  owner: Pubkey,
+  order: Pubkey,
+  hylo: &Hylo,
+) -> ExecuteOrderL2sLst {
+  ExecuteOrderL2sLst {
+    executor,
+    owner,
+    hylo: pda::HYLO,
+    sol_usd_pyth_feed: hylo.sol_usd_oracle,
+    hyusd_mint: HYUSD::MINT,
+    stablecoin_auth: pda::HYUSD_AUTH,
+    fee_auth: pda::fee_auth(HYUSD::MINT),
+    fee_vault: pda::fee_vault(HYUSD::MINT),
+    xsol_mint: XSOL::MINT,
+    levercoin_auth: pda::XSOL_AUTH,
+    order,
+    order_xsol_vault: pda::ata(order, XSOL::MINT),
+    order_hyusd_vault: pda::ata(order, HYUSD::MINT),
+    owner_hyusd_ta: pda::ata(owner, HYUSD::MINT),
+    hylo_exchange_event_authority: pda::EXCHANGE_EVENT_AUTHORITY,
+    hylo_exchange_program: crate::exchange::ID,
+    event_authority: pda::trigger_orders_event_authority(),
+    program: trigger_orders::ID,
+    token_program: token::ID,
+    associated_token_program: associated_token::ID,
+    system_program: system_program::ID,
+  }
+}
+
+/// Builds account context for executing a stable-to-lever order (EXO).
+///
+/// `_hylo` is accepted for signature symmetry with the LST builders; the EXO
+/// CPI uses the per-pair `exo_pair.oracle` rather than the Hylo SOL/USD oracle.
+#[must_use]
+pub fn execute_order_s2l_exo(
+  executor: Pubkey,
+  owner: Pubkey,
+  order: Pubkey,
+  collateral_mint: Pubkey,
+  _hylo: &Hylo,
+  exo_pair: &ExoPair,
+) -> ExecuteOrderS2lExo {
+  let levercoin_mint = pda::exo_levercoin_mint(collateral_mint);
+  let vault_auth = pda::exo_vault_auth(collateral_mint);
+  ExecuteOrderS2lExo {
+    executor,
+    owner,
+    hylo: pda::HYLO,
+    exo_pair: pda::exo_pair(collateral_mint),
+    collateral_mint,
+    vault_auth,
+    collateral_vault: pda::ata(vault_auth, collateral_mint),
+    collateral_usd_pyth_feed: exo_pair.oracle,
+    hyusd_mint: HYUSD::MINT,
+    stablecoin_auth: pda::HYUSD_AUTH,
+    fee_auth: pda::fee_auth(HYUSD::MINT),
+    fee_vault: pda::fee_vault(HYUSD::MINT),
+    levercoin_mint,
+    levercoin_auth: pda::mint_auth(levercoin_mint),
+    order,
+    order_hyusd_vault: pda::ata(order, HYUSD::MINT),
+    order_levercoin_vault: pda::ata(order, levercoin_mint),
+    owner_levercoin_ta: pda::ata(owner, levercoin_mint),
+    hylo_exchange_event_authority: pda::EXCHANGE_EVENT_AUTHORITY,
+    hylo_exchange_program: crate::exchange::ID,
+    token_program: token::ID,
+    associated_token_program: associated_token::ID,
+    system_program: system_program::ID,
+    event_authority: pda::trigger_orders_event_authority(),
+    program: trigger_orders::ID,
+  }
+}
+
+/// Builds account context for executing a lever-to-stable order (EXO).
+///
+/// `_hylo` is accepted for signature symmetry with the LST builders; the EXO
+/// CPI uses the per-pair `exo_pair.oracle` rather than the Hylo SOL/USD oracle.
+#[must_use]
+pub fn execute_order_l2s_exo(
+  executor: Pubkey,
+  owner: Pubkey,
+  order: Pubkey,
+  collateral_mint: Pubkey,
+  _hylo: &Hylo,
+  exo_pair: &ExoPair,
+) -> ExecuteOrderL2sExo {
+  let levercoin_mint = pda::exo_levercoin_mint(collateral_mint);
+  let vault_auth = pda::exo_vault_auth(collateral_mint);
+  ExecuteOrderL2sExo {
+    executor,
+    owner,
+    hylo: pda::HYLO,
+    exo_pair: pda::exo_pair(collateral_mint),
+    collateral_mint,
+    vault_auth,
+    collateral_vault: pda::ata(vault_auth, collateral_mint),
+    collateral_usd_pyth_feed: exo_pair.oracle,
+    hyusd_mint: HYUSD::MINT,
+    stablecoin_auth: pda::HYUSD_AUTH,
+    fee_auth: pda::fee_auth(HYUSD::MINT),
+    fee_vault: pda::fee_vault(HYUSD::MINT),
+    levercoin_mint,
+    levercoin_auth: pda::mint_auth(levercoin_mint),
+    order,
+    order_levercoin_vault: pda::ata(order, levercoin_mint),
+    order_hyusd_vault: pda::ata(order, HYUSD::MINT),
+    owner_hyusd_ta: pda::ata(owner, HYUSD::MINT),
+    hylo_exchange_event_authority: pda::EXCHANGE_EVENT_AUTHORITY,
+    hylo_exchange_program: crate::exchange::ID,
+    token_program: token::ID,
+    associated_token_program: associated_token::ID,
+    system_program: system_program::ID,
+    event_authority: pda::trigger_orders_event_authority(),
+    program: trigger_orders::ID,
+  }
+}
+
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::exchange::types::{
+    BorrowRateConfig, HarvestCache, LevercoinFees, PoolDrawdown,
+    RebalanceCurveConfig, UFixValue64, VirtualStablecoin,
+  };
+
+  fn healthy_hylo_min() -> crate::exchange::accounts::Hylo {
+    crate::exchange::accounts::Hylo::default()
+  }
+
+  // `ExoPair` does NOT derive `Default` (its `_reserved: [u8; 100]` exceeds
+  // the 32-element auto-Default array limit), so list every field explicitly.
+  // The builder only reads `exo_pair.oracle`, which the test sets explicitly.
+  fn healthy_exo_pair_min() -> ExoPair {
+    ExoPair {
+      collateral_mint: Pubkey::new_unique(),
+      levercoin_mint_bump: 0,
+      levercoin_auth_bump: 0,
+      vault_auth_bump: 0,
+      fee_auth_bump: 0,
+      oracle: Pubkey::new_unique(),
+      oracle_feed_id: [0u8; 32],
+      oracle_interval_secs: 30,
+      oracle_conf_tolerance: UFixValue64::default(),
+      stablecoin_mint_threshold: UFixValue64::default(),
+      virtual_stablecoin: VirtualStablecoin::default(),
+      borrow_rate_config: BorrowRateConfig::default(),
+      borrow_rate_harvest_cache: HarvestCache::default(),
+      levercoin_fees: LevercoinFees::default(),
+      sell_curve_config: RebalanceCurveConfig::default(),
+      buy_curve_config: RebalanceCurveConfig::default(),
+      rebalance_deviation_tolerance: UFixValue64::default(),
+      paused: false,
+      levercoin_market_cap_limit: UFixValue64::default(),
+      pool_drawdown: PoolDrawdown::default(),
+      _reserved: [0u8; 100],
+    }
+  }
+
+  #[test]
+  fn execute_order_s2l_lst_threads_hylo_oracle() {
+    let executor = Pubkey::new_unique();
+    let owner = Pubkey::new_unique();
+    let order = Pubkey::new_unique();
+    let mut hylo = healthy_hylo_min();
+    let oracle = Pubkey::new_unique();
+    hylo.sol_usd_oracle = oracle;
+
+    let a = execute_order_s2l_lst(executor, owner, order, &hylo);
+
+    assert_eq!(a.executor, executor);
+    assert_eq!(a.owner, owner);
+    assert_eq!(a.hylo, pda::HYLO);
+    assert_eq!(a.sol_usd_pyth_feed, oracle);
+    assert_eq!(a.hyusd_mint, HYUSD::MINT);
+    assert_eq!(a.stablecoin_auth, pda::HYUSD_AUTH);
+    assert_eq!(a.fee_auth, pda::fee_auth(HYUSD::MINT));
+    assert_eq!(a.fee_vault, pda::fee_vault(HYUSD::MINT));
+    assert_eq!(a.xsol_mint, XSOL::MINT);
+    assert_eq!(a.levercoin_auth, pda::XSOL_AUTH);
+    assert_eq!(a.order, order);
+    assert_eq!(a.order_hyusd_vault, pda::ata(order, HYUSD::MINT));
+    assert_eq!(a.order_xsol_vault, pda::ata(order, XSOL::MINT));
+    assert_eq!(a.owner_xsol_ta, pda::ata(owner, XSOL::MINT));
+    assert_eq!(
+      a.hylo_exchange_event_authority,
+      pda::EXCHANGE_EVENT_AUTHORITY
+    );
+    assert_eq!(a.hylo_exchange_program, crate::exchange::ID);
+    assert_eq!(a.event_authority, pda::trigger_orders_event_authority());
+    assert_eq!(a.program, trigger_orders::ID);
+    assert_eq!(a.token_program, token::ID);
+    assert_eq!(a.associated_token_program, associated_token::ID);
+    assert_eq!(a.system_program, system_program::ID);
+  }
+
+  #[test]
+  fn execute_order_l2s_lst_threads_hylo_oracle() {
+    let executor = Pubkey::new_unique();
+    let owner = Pubkey::new_unique();
+    let order = Pubkey::new_unique();
+    let mut hylo = healthy_hylo_min();
+    let oracle = Pubkey::new_unique();
+    hylo.sol_usd_oracle = oracle;
+
+    let a = execute_order_l2s_lst(executor, owner, order, &hylo);
+
+    assert_eq!(a.executor, executor);
+    assert_eq!(a.owner, owner);
+    assert_eq!(a.hylo, pda::HYLO);
+    assert_eq!(a.sol_usd_pyth_feed, oracle);
+    assert_eq!(a.hyusd_mint, HYUSD::MINT);
+    assert_eq!(a.stablecoin_auth, pda::HYUSD_AUTH);
+    assert_eq!(a.fee_auth, pda::fee_auth(HYUSD::MINT));
+    assert_eq!(a.fee_vault, pda::fee_vault(HYUSD::MINT));
+    assert_eq!(a.xsol_mint, XSOL::MINT);
+    assert_eq!(a.levercoin_auth, pda::XSOL_AUTH);
+    assert_eq!(a.order, order);
+    assert_eq!(a.order_xsol_vault, pda::ata(order, XSOL::MINT));
+    assert_eq!(a.order_hyusd_vault, pda::ata(order, HYUSD::MINT));
+    assert_eq!(a.owner_hyusd_ta, pda::ata(owner, HYUSD::MINT));
+    assert_eq!(
+      a.hylo_exchange_event_authority,
+      pda::EXCHANGE_EVENT_AUTHORITY
+    );
+    assert_eq!(a.hylo_exchange_program, crate::exchange::ID);
+    assert_eq!(a.event_authority, pda::trigger_orders_event_authority());
+    assert_eq!(a.program, trigger_orders::ID);
+    assert_eq!(a.token_program, token::ID);
+    assert_eq!(a.associated_token_program, associated_token::ID);
+    assert_eq!(a.system_program, system_program::ID);
+  }
+
+  #[test]
+  fn execute_order_s2l_exo_threads_exo_oracle() {
+    let executor = Pubkey::new_unique();
+    let owner = Pubkey::new_unique();
+    let order = Pubkey::new_unique();
+    let collateral_mint = Pubkey::new_unique();
+    let hylo = healthy_hylo_min();
+    let mut exo_pair = healthy_exo_pair_min();
+    let oracle = Pubkey::new_unique();
+    exo_pair.oracle = oracle;
+    let levercoin_mint = pda::exo_levercoin_mint(collateral_mint);
+    let vault_auth = pda::exo_vault_auth(collateral_mint);
+
+    let a = execute_order_s2l_exo(
+      executor,
+      owner,
+      order,
+      collateral_mint,
+      &hylo,
+      &exo_pair,
+    );
+
+    assert_eq!(a.executor, executor);
+    assert_eq!(a.owner, owner);
+    assert_eq!(a.hylo, pda::HYLO);
+    assert_eq!(a.exo_pair, pda::exo_pair(collateral_mint));
+    assert_eq!(a.collateral_mint, collateral_mint);
+    assert_eq!(a.vault_auth, vault_auth);
+    assert_eq!(a.collateral_vault, pda::ata(vault_auth, collateral_mint));
+    assert_eq!(a.collateral_usd_pyth_feed, oracle);
+    assert_eq!(a.hyusd_mint, HYUSD::MINT);
+    assert_eq!(a.stablecoin_auth, pda::HYUSD_AUTH);
+    assert_eq!(a.fee_auth, pda::fee_auth(HYUSD::MINT));
+    assert_eq!(a.fee_vault, pda::fee_vault(HYUSD::MINT));
+    assert_eq!(a.levercoin_mint, levercoin_mint);
+    assert_eq!(a.levercoin_auth, pda::mint_auth(levercoin_mint));
+    assert_eq!(a.order, order);
+    assert_eq!(a.order_hyusd_vault, pda::ata(order, HYUSD::MINT));
+    assert_eq!(a.order_levercoin_vault, pda::ata(order, levercoin_mint));
+    assert_eq!(a.owner_levercoin_ta, pda::ata(owner, levercoin_mint));
+    assert_eq!(
+      a.hylo_exchange_event_authority,
+      pda::EXCHANGE_EVENT_AUTHORITY
+    );
+    assert_eq!(a.hylo_exchange_program, crate::exchange::ID);
+    assert_eq!(a.token_program, token::ID);
+    assert_eq!(a.associated_token_program, associated_token::ID);
+    assert_eq!(a.system_program, system_program::ID);
+    assert_eq!(a.event_authority, pda::trigger_orders_event_authority());
+    assert_eq!(a.program, trigger_orders::ID);
+  }
+
+  #[test]
+  fn execute_order_l2s_exo_threads_exo_oracle() {
+    let executor = Pubkey::new_unique();
+    let owner = Pubkey::new_unique();
+    let order = Pubkey::new_unique();
+    let collateral_mint = Pubkey::new_unique();
+    let hylo = healthy_hylo_min();
+    let mut exo_pair = healthy_exo_pair_min();
+    let oracle = Pubkey::new_unique();
+    exo_pair.oracle = oracle;
+    let levercoin_mint = pda::exo_levercoin_mint(collateral_mint);
+    let vault_auth = pda::exo_vault_auth(collateral_mint);
+
+    let a = execute_order_l2s_exo(
+      executor,
+      owner,
+      order,
+      collateral_mint,
+      &hylo,
+      &exo_pair,
+    );
+
+    assert_eq!(a.executor, executor);
+    assert_eq!(a.owner, owner);
+    assert_eq!(a.hylo, pda::HYLO);
+    assert_eq!(a.exo_pair, pda::exo_pair(collateral_mint));
+    assert_eq!(a.collateral_mint, collateral_mint);
+    assert_eq!(a.vault_auth, vault_auth);
+    assert_eq!(a.collateral_vault, pda::ata(vault_auth, collateral_mint));
+    assert_eq!(a.collateral_usd_pyth_feed, oracle);
+    assert_eq!(a.hyusd_mint, HYUSD::MINT);
+    assert_eq!(a.stablecoin_auth, pda::HYUSD_AUTH);
+    assert_eq!(a.fee_auth, pda::fee_auth(HYUSD::MINT));
+    assert_eq!(a.fee_vault, pda::fee_vault(HYUSD::MINT));
+    assert_eq!(a.levercoin_mint, levercoin_mint);
+    assert_eq!(a.levercoin_auth, pda::mint_auth(levercoin_mint));
+    assert_eq!(a.order, order);
+    assert_eq!(a.order_levercoin_vault, pda::ata(order, levercoin_mint));
+    assert_eq!(a.order_hyusd_vault, pda::ata(order, HYUSD::MINT));
+    assert_eq!(a.owner_hyusd_ta, pda::ata(owner, HYUSD::MINT));
+    assert_eq!(
+      a.hylo_exchange_event_authority,
+      pda::EXCHANGE_EVENT_AUTHORITY
+    );
+    assert_eq!(a.hylo_exchange_program, crate::exchange::ID);
+    assert_eq!(a.token_program, token::ID);
+    assert_eq!(a.associated_token_program, associated_token::ID);
+    assert_eq!(a.system_program, system_program::ID);
+    assert_eq!(a.event_authority, pda::trigger_orders_event_authority());
+    assert_eq!(a.program, trigger_orders::ID);
+  }
 
   #[test]
   fn create_order_s2l_lst_builds_correct_pdas() {

--- a/hylo-idl/src/account_builders/trigger_orders.rs
+++ b/hylo-idl/src/account_builders/trigger_orders.rs
@@ -8,9 +8,9 @@ use anchor_spl::{associated_token, token};
 use crate::exchange::accounts::{ExoPair, Hylo};
 use crate::tokens::{TokenMint, HYUSD, XSOL};
 use crate::trigger_orders::client::accounts::{
-  CreateOrderL2sExo, CreateOrderL2sLst, CreateOrderS2lExo, CreateOrderS2lLst,
-  ExecuteOrderL2sExo, ExecuteOrderL2sLst, ExecuteOrderS2lExo,
-  ExecuteOrderS2lLst,
+  CancelOrderL2sExo, CancelOrderL2sLst, CancelOrderS2l, CreateOrderL2sExo,
+  CreateOrderL2sLst, CreateOrderS2lExo, CreateOrderS2lLst, ExecuteOrderL2sExo,
+  ExecuteOrderL2sLst, ExecuteOrderS2lExo, ExecuteOrderS2lLst,
 };
 use crate::{pda, trigger_orders};
 
@@ -248,6 +248,60 @@ pub fn execute_order_l2s_exo(
     system_program: system_program::ID,
     event_authority: pda::trigger_orders_event_authority(),
     program: trigger_orders::ID,
+  }
+}
+
+/// Builds account context for cancelling a stable-to-lever order.
+///
+/// Handles both LST and EXO s2l orders: the s2l escrow is always HYUSD
+/// regardless of the order's lever target, so no collateral mint is needed.
+#[must_use]
+pub fn cancel_order_s2l(owner: Pubkey, order: Pubkey) -> CancelOrderS2l {
+  CancelOrderS2l {
+    owner,
+    order,
+    order_hyusd_vault: pda::ata(order, HYUSD::MINT),
+    owner_hyusd_ta: pda::ata(owner, HYUSD::MINT),
+    hyusd_mint: HYUSD::MINT,
+    event_authority: pda::trigger_orders_event_authority(),
+    program: trigger_orders::ID,
+    token_program: token::ID,
+  }
+}
+
+/// Builds account context for cancelling a lever-to-stable order (LST).
+#[must_use]
+pub fn cancel_order_l2s_lst(owner: Pubkey, order: Pubkey) -> CancelOrderL2sLst {
+  CancelOrderL2sLst {
+    owner,
+    order,
+    order_xsol_vault: pda::ata(order, XSOL::MINT),
+    owner_xsol_ta: pda::ata(owner, XSOL::MINT),
+    xsol_mint: XSOL::MINT,
+    event_authority: pda::trigger_orders_event_authority(),
+    program: trigger_orders::ID,
+    token_program: token::ID,
+  }
+}
+
+/// Builds account context for cancelling a lever-to-stable order (EXO).
+#[must_use]
+pub fn cancel_order_l2s_exo(
+  owner: Pubkey,
+  order: Pubkey,
+  collateral_mint: Pubkey,
+) -> CancelOrderL2sExo {
+  let levercoin_mint = pda::exo_levercoin_mint(collateral_mint);
+  CancelOrderL2sExo {
+    owner,
+    order,
+    order_levercoin_vault: pda::ata(order, levercoin_mint),
+    owner_levercoin_ta: pda::ata(owner, levercoin_mint),
+    levercoin_mint,
+    collateral_mint,
+    event_authority: pda::trigger_orders_event_authority(),
+    program: trigger_orders::ID,
+    token_program: token::ID,
   }
 }
 
@@ -549,5 +603,53 @@ mod tests {
     assert_eq!(a.associated_token_program, associated_token::ID);
     assert_eq!(a.system_program, system_program::ID);
     assert_eq!(a.rent, rent::ID);
+  }
+
+  #[test]
+  fn cancel_order_s2l_minimal_fields() {
+    let owner = Pubkey::new_unique();
+    let order = Pubkey::new_unique();
+    let a = cancel_order_s2l(owner, order);
+    assert_eq!(a.owner, owner);
+    assert_eq!(a.order, order);
+    assert_eq!(a.order_hyusd_vault, pda::ata(order, HYUSD::MINT));
+    assert_eq!(a.owner_hyusd_ta, pda::ata(owner, HYUSD::MINT));
+    assert_eq!(a.hyusd_mint, HYUSD::MINT);
+    assert_eq!(a.event_authority, pda::trigger_orders_event_authority());
+    assert_eq!(a.program, trigger_orders::ID);
+    assert_eq!(a.token_program, token::ID);
+  }
+
+  #[test]
+  fn cancel_order_l2s_lst_minimal_fields() {
+    let owner = Pubkey::new_unique();
+    let order = Pubkey::new_unique();
+    let a = cancel_order_l2s_lst(owner, order);
+    assert_eq!(a.owner, owner);
+    assert_eq!(a.order, order);
+    assert_eq!(a.order_xsol_vault, pda::ata(order, XSOL::MINT));
+    assert_eq!(a.owner_xsol_ta, pda::ata(owner, XSOL::MINT));
+    assert_eq!(a.xsol_mint, XSOL::MINT);
+    assert_eq!(a.event_authority, pda::trigger_orders_event_authority());
+    assert_eq!(a.program, trigger_orders::ID);
+    assert_eq!(a.token_program, token::ID);
+  }
+
+  #[test]
+  fn cancel_order_l2s_exo_minimal_fields() {
+    let owner = Pubkey::new_unique();
+    let order = Pubkey::new_unique();
+    let collateral_mint = Pubkey::new_unique();
+    let levercoin_mint = pda::exo_levercoin_mint(collateral_mint);
+    let a = cancel_order_l2s_exo(owner, order, collateral_mint);
+    assert_eq!(a.owner, owner);
+    assert_eq!(a.order, order);
+    assert_eq!(a.order_levercoin_vault, pda::ata(order, levercoin_mint));
+    assert_eq!(a.owner_levercoin_ta, pda::ata(owner, levercoin_mint));
+    assert_eq!(a.levercoin_mint, levercoin_mint);
+    assert_eq!(a.collateral_mint, collateral_mint);
+    assert_eq!(a.event_authority, pda::trigger_orders_event_authority());
+    assert_eq!(a.program, trigger_orders::ID);
+    assert_eq!(a.token_program, token::ID);
   }
 }

--- a/hylo-idl/src/instruction_builders/mod.rs
+++ b/hylo-idl/src/instruction_builders/mod.rs
@@ -1,3 +1,4 @@
 pub mod earn_pool;
 pub mod exchange;
 pub mod router;
+pub mod trigger_orders;

--- a/hylo-idl/src/instruction_builders/trigger_orders.rs
+++ b/hylo-idl/src/instruction_builders/trigger_orders.rs
@@ -10,12 +10,13 @@ use crate::trigger_orders::account_builders;
 use crate::trigger_orders::client::args;
 
 #[must_use]
-pub fn create_order_s2l_lst(
+pub fn create_order_stable_to_lever_lst(
   owner: Pubkey,
   order: Pubkey,
-  args: &args::CreateOrderS2lLst,
+  args: &args::CreateOrderStableToLeverLst,
 ) -> Instruction {
-  let accounts = account_builders::create_order_s2l_lst(owner, order);
+  let accounts =
+    account_builders::create_order_stable_to_lever_lst(owner, order);
   Instruction {
     program_id: trigger_orders::ID,
     accounts: accounts.to_account_metas(None),
@@ -24,14 +25,17 @@ pub fn create_order_s2l_lst(
 }
 
 #[must_use]
-pub fn create_order_s2l_exo(
+pub fn create_order_stable_to_lever_exo(
   owner: Pubkey,
   order: Pubkey,
   collateral_mint: Pubkey,
-  args: &args::CreateOrderS2lExo,
+  args: &args::CreateOrderStableToLeverExo,
 ) -> Instruction {
-  let accounts =
-    account_builders::create_order_s2l_exo(owner, order, collateral_mint);
+  let accounts = account_builders::create_order_stable_to_lever_exo(
+    owner,
+    order,
+    collateral_mint,
+  );
   Instruction {
     program_id: trigger_orders::ID,
     accounts: accounts.to_account_metas(None),
@@ -40,12 +44,13 @@ pub fn create_order_s2l_exo(
 }
 
 #[must_use]
-pub fn create_order_l2s_lst(
+pub fn create_order_lever_to_stable_lst(
   owner: Pubkey,
   order: Pubkey,
-  args: &args::CreateOrderL2sLst,
+  args: &args::CreateOrderLeverToStableLst,
 ) -> Instruction {
-  let accounts = account_builders::create_order_l2s_lst(owner, order);
+  let accounts =
+    account_builders::create_order_lever_to_stable_lst(owner, order);
   Instruction {
     program_id: trigger_orders::ID,
     accounts: accounts.to_account_metas(None),
@@ -54,14 +59,17 @@ pub fn create_order_l2s_lst(
 }
 
 #[must_use]
-pub fn create_order_l2s_exo(
+pub fn create_order_lever_to_stable_exo(
   owner: Pubkey,
   order: Pubkey,
   collateral_mint: Pubkey,
-  args: &args::CreateOrderL2sExo,
+  args: &args::CreateOrderLeverToStableExo,
 ) -> Instruction {
-  let accounts =
-    account_builders::create_order_l2s_exo(owner, order, collateral_mint);
+  let accounts = account_builders::create_order_lever_to_stable_exo(
+    owner,
+    order,
+    collateral_mint,
+  );
   Instruction {
     program_id: trigger_orders::ID,
     accounts: accounts.to_account_metas(None),
@@ -70,39 +78,41 @@ pub fn create_order_l2s_exo(
 }
 
 #[must_use]
-pub fn execute_order_s2l_lst(
+pub fn execute_order_stable_to_lever_lst(
   executor: Pubkey,
   owner: Pubkey,
   order: Pubkey,
   hylo: &Hylo,
 ) -> Instruction {
-  let accounts =
-    account_builders::execute_order_s2l_lst(executor, owner, order, hylo);
+  let accounts = account_builders::execute_order_stable_to_lever_lst(
+    executor, owner, order, hylo,
+  );
   Instruction {
     program_id: trigger_orders::ID,
     accounts: accounts.to_account_metas(None),
-    data: args::ExecuteOrderS2lLst {}.data(),
+    data: args::ExecuteOrderStableToLeverLst {}.data(),
   }
 }
 
 #[must_use]
-pub fn execute_order_l2s_lst(
+pub fn execute_order_lever_to_stable_lst(
   executor: Pubkey,
   owner: Pubkey,
   order: Pubkey,
   hylo: &Hylo,
 ) -> Instruction {
-  let accounts =
-    account_builders::execute_order_l2s_lst(executor, owner, order, hylo);
+  let accounts = account_builders::execute_order_lever_to_stable_lst(
+    executor, owner, order, hylo,
+  );
   Instruction {
     program_id: trigger_orders::ID,
     accounts: accounts.to_account_metas(None),
-    data: args::ExecuteOrderL2sLst {}.data(),
+    data: args::ExecuteOrderLeverToStableLst {}.data(),
   }
 }
 
 #[must_use]
-pub fn execute_order_s2l_exo(
+pub fn execute_order_stable_to_lever_exo(
   executor: Pubkey,
   owner: Pubkey,
   order: Pubkey,
@@ -110,7 +120,7 @@ pub fn execute_order_s2l_exo(
   hylo: &Hylo,
   exo_pair: &ExoPair,
 ) -> Instruction {
-  let accounts = account_builders::execute_order_s2l_exo(
+  let accounts = account_builders::execute_order_stable_to_lever_exo(
     executor,
     owner,
     order,
@@ -121,12 +131,12 @@ pub fn execute_order_s2l_exo(
   Instruction {
     program_id: trigger_orders::ID,
     accounts: accounts.to_account_metas(None),
-    data: args::ExecuteOrderS2lExo {}.data(),
+    data: args::ExecuteOrderStableToLeverExo {}.data(),
   }
 }
 
 #[must_use]
-pub fn execute_order_l2s_exo(
+pub fn execute_order_lever_to_stable_exo(
   executor: Pubkey,
   owner: Pubkey,
   order: Pubkey,
@@ -134,7 +144,7 @@ pub fn execute_order_l2s_exo(
   hylo: &Hylo,
   exo_pair: &ExoPair,
 ) -> Instruction {
-  let accounts = account_builders::execute_order_l2s_exo(
+  let accounts = account_builders::execute_order_lever_to_stable_exo(
     executor,
     owner,
     order,
@@ -145,17 +155,17 @@ pub fn execute_order_l2s_exo(
   Instruction {
     program_id: trigger_orders::ID,
     accounts: accounts.to_account_metas(None),
-    data: args::ExecuteOrderL2sExo {}.data(),
+    data: args::ExecuteOrderLeverToStableExo {}.data(),
   }
 }
 
 #[must_use]
-pub fn cancel_order_s2l(
+pub fn cancel_order_stable_to_lever(
   owner: Pubkey,
   order: Pubkey,
-  args: &args::CancelOrderS2l,
+  args: &args::CancelOrderStableToLever,
 ) -> Instruction {
-  let accounts = account_builders::cancel_order_s2l(owner, order);
+  let accounts = account_builders::cancel_order_stable_to_lever(owner, order);
   Instruction {
     program_id: trigger_orders::ID,
     accounts: accounts.to_account_metas(None),
@@ -164,12 +174,13 @@ pub fn cancel_order_s2l(
 }
 
 #[must_use]
-pub fn cancel_order_l2s_lst(
+pub fn cancel_order_lever_to_stable_lst(
   owner: Pubkey,
   order: Pubkey,
-  args: &args::CancelOrderL2sLst,
+  args: &args::CancelOrderLeverToStableLst,
 ) -> Instruction {
-  let accounts = account_builders::cancel_order_l2s_lst(owner, order);
+  let accounts =
+    account_builders::cancel_order_lever_to_stable_lst(owner, order);
   Instruction {
     program_id: trigger_orders::ID,
     accounts: accounts.to_account_metas(None),
@@ -178,14 +189,17 @@ pub fn cancel_order_l2s_lst(
 }
 
 #[must_use]
-pub fn cancel_order_l2s_exo(
+pub fn cancel_order_lever_to_stable_exo(
   owner: Pubkey,
   order: Pubkey,
   collateral_mint: Pubkey,
-  args: &args::CancelOrderL2sExo,
+  args: &args::CancelOrderLeverToStableExo,
 ) -> Instruction {
-  let accounts =
-    account_builders::cancel_order_l2s_exo(owner, order, collateral_mint);
+  let accounts = account_builders::cancel_order_lever_to_stable_exo(
+    owner,
+    order,
+    collateral_mint,
+  );
   Instruction {
     program_id: trigger_orders::ID,
     accounts: accounts.to_account_metas(None),
@@ -202,8 +216,8 @@ mod tests {
   };
   use crate::trigger_orders::types::TriggerDirection;
 
-  fn create_args_l2s_lst() -> args::CreateOrderL2sLst {
-    args::CreateOrderL2sLst {
+  fn create_args_lever_to_stable_lst() -> args::CreateOrderLeverToStableLst {
+    args::CreateOrderLeverToStableLst {
       nonce: 42,
       escrow_amount: 1000,
       trigger_price: 100,
@@ -212,8 +226,8 @@ mod tests {
     }
   }
 
-  fn create_args_l2s_exo() -> args::CreateOrderL2sExo {
-    args::CreateOrderL2sExo {
+  fn create_args_lever_to_stable_exo() -> args::CreateOrderLeverToStableExo {
+    args::CreateOrderLeverToStableExo {
       nonce: 42,
       escrow_amount: 1000,
       trigger_price: 100,
@@ -222,8 +236,8 @@ mod tests {
     }
   }
 
-  fn create_args_s2l_exo() -> args::CreateOrderS2lExo {
-    args::CreateOrderS2lExo {
+  fn create_args_stable_to_lever_exo() -> args::CreateOrderStableToLeverExo {
+    args::CreateOrderStableToLeverExo {
       nonce: 42,
       escrow_amount: 1000,
       trigger_price: 100,
@@ -265,17 +279,17 @@ mod tests {
   }
 
   #[test]
-  fn create_order_s2l_lst_returns_well_formed_instruction() {
+  fn create_order_stable_to_lever_lst_returns_well_formed_instruction() {
     let owner = Pubkey::new_unique();
     let order = Pubkey::new_unique();
-    let args = args::CreateOrderS2lLst {
+    let args = args::CreateOrderStableToLeverLst {
       nonce: 42,
       escrow_amount: 1000,
       trigger_price: 100,
       trigger_expo: -8,
       direction: TriggerDirection::AtOrAbove,
     };
-    let ix = create_order_s2l_lst(owner, order, &args);
+    let ix = create_order_stable_to_lever_lst(owner, order, &args);
     assert_eq!(ix.program_id, trigger_orders::ID);
     // Anchor: 8-byte discriminator + borsh args.
     // 8 + 8(nonce u64) + 8(escrow u64) + 8(trigger_price i64) + 4(expo i32)
@@ -289,15 +303,15 @@ mod tests {
   }
 
   #[test]
-  fn create_order_s2l_exo_returns_well_formed_instruction() {
+  fn create_order_stable_to_lever_exo_returns_well_formed_instruction() {
     let owner = Pubkey::new_unique();
     let order = Pubkey::new_unique();
     let collateral_mint = Pubkey::new_unique();
-    let ix = create_order_s2l_exo(
+    let ix = create_order_stable_to_lever_exo(
       owner,
       order,
       collateral_mint,
-      &create_args_s2l_exo(),
+      &create_args_stable_to_lever_exo(),
     );
     assert_eq!(ix.program_id, trigger_orders::ID);
     assert_eq!(ix.data.len(), 37);
@@ -307,10 +321,14 @@ mod tests {
   }
 
   #[test]
-  fn create_order_l2s_lst_returns_well_formed_instruction() {
+  fn create_order_lever_to_stable_lst_returns_well_formed_instruction() {
     let owner = Pubkey::new_unique();
     let order = Pubkey::new_unique();
-    let ix = create_order_l2s_lst(owner, order, &create_args_l2s_lst());
+    let ix = create_order_lever_to_stable_lst(
+      owner,
+      order,
+      &create_args_lever_to_stable_lst(),
+    );
     assert_eq!(ix.program_id, trigger_orders::ID);
     assert_eq!(ix.data.len(), 37);
     assert_eq!(ix.accounts.len(), 11);
@@ -319,15 +337,15 @@ mod tests {
   }
 
   #[test]
-  fn create_order_l2s_exo_returns_well_formed_instruction() {
+  fn create_order_lever_to_stable_exo_returns_well_formed_instruction() {
     let owner = Pubkey::new_unique();
     let order = Pubkey::new_unique();
     let collateral_mint = Pubkey::new_unique();
-    let ix = create_order_l2s_exo(
+    let ix = create_order_lever_to_stable_exo(
       owner,
       order,
       collateral_mint,
-      &create_args_l2s_exo(),
+      &create_args_lever_to_stable_exo(),
     );
     assert_eq!(ix.program_id, trigger_orders::ID);
     assert_eq!(ix.data.len(), 37);
@@ -337,12 +355,12 @@ mod tests {
   }
 
   #[test]
-  fn execute_order_s2l_lst_returns_well_formed_instruction() {
+  fn execute_order_stable_to_lever_lst_returns_well_formed_instruction() {
     let executor = Pubkey::new_unique();
     let owner = Pubkey::new_unique();
     let order = Pubkey::new_unique();
     let hylo = healthy_hylo_min();
-    let ix = execute_order_s2l_lst(executor, owner, order, &hylo);
+    let ix = execute_order_stable_to_lever_lst(executor, owner, order, &hylo);
     assert_eq!(ix.program_id, trigger_orders::ID);
     assert_eq!(ix.data.len(), 8);
     assert_eq!(ix.accounts.len(), 21);
@@ -350,12 +368,12 @@ mod tests {
   }
 
   #[test]
-  fn execute_order_l2s_lst_returns_well_formed_instruction() {
+  fn execute_order_lever_to_stable_lst_returns_well_formed_instruction() {
     let executor = Pubkey::new_unique();
     let owner = Pubkey::new_unique();
     let order = Pubkey::new_unique();
     let hylo = healthy_hylo_min();
-    let ix = execute_order_l2s_lst(executor, owner, order, &hylo);
+    let ix = execute_order_lever_to_stable_lst(executor, owner, order, &hylo);
     assert_eq!(ix.program_id, trigger_orders::ID);
     assert_eq!(ix.data.len(), 8);
     assert_eq!(ix.accounts.len(), 21);
@@ -363,14 +381,14 @@ mod tests {
   }
 
   #[test]
-  fn execute_order_s2l_exo_returns_well_formed_instruction() {
+  fn execute_order_stable_to_lever_exo_returns_well_formed_instruction() {
     let executor = Pubkey::new_unique();
     let owner = Pubkey::new_unique();
     let order = Pubkey::new_unique();
     let collateral_mint = Pubkey::new_unique();
     let hylo = healthy_hylo_min();
     let exo_pair = healthy_exo_pair_min();
-    let ix = execute_order_s2l_exo(
+    let ix = execute_order_stable_to_lever_exo(
       executor,
       owner,
       order,
@@ -385,14 +403,14 @@ mod tests {
   }
 
   #[test]
-  fn execute_order_l2s_exo_returns_well_formed_instruction() {
+  fn execute_order_lever_to_stable_exo_returns_well_formed_instruction() {
     let executor = Pubkey::new_unique();
     let owner = Pubkey::new_unique();
     let order = Pubkey::new_unique();
     let collateral_mint = Pubkey::new_unique();
     let hylo = healthy_hylo_min();
     let exo_pair = healthy_exo_pair_min();
-    let ix = execute_order_l2s_exo(
+    let ix = execute_order_lever_to_stable_exo(
       executor,
       owner,
       order,
@@ -407,10 +425,14 @@ mod tests {
   }
 
   #[test]
-  fn cancel_order_s2l_returns_well_formed_instruction() {
+  fn cancel_order_stable_to_lever_returns_well_formed_instruction() {
     let owner = Pubkey::new_unique();
     let order = Pubkey::new_unique();
-    let ix = cancel_order_s2l(owner, order, &args::CancelOrderS2l {});
+    let ix = cancel_order_stable_to_lever(
+      owner,
+      order,
+      &args::CancelOrderStableToLever {},
+    );
     assert_eq!(ix.program_id, trigger_orders::ID);
     assert_eq!(ix.data.len(), 8);
     assert_eq!(ix.accounts.len(), 8);
@@ -419,10 +441,14 @@ mod tests {
   }
 
   #[test]
-  fn cancel_order_l2s_lst_returns_well_formed_instruction() {
+  fn cancel_order_lever_to_stable_lst_returns_well_formed_instruction() {
     let owner = Pubkey::new_unique();
     let order = Pubkey::new_unique();
-    let ix = cancel_order_l2s_lst(owner, order, &args::CancelOrderL2sLst {});
+    let ix = cancel_order_lever_to_stable_lst(
+      owner,
+      order,
+      &args::CancelOrderLeverToStableLst {},
+    );
     assert_eq!(ix.program_id, trigger_orders::ID);
     assert_eq!(ix.data.len(), 8);
     assert_eq!(ix.accounts.len(), 8);
@@ -431,15 +457,15 @@ mod tests {
   }
 
   #[test]
-  fn cancel_order_l2s_exo_returns_well_formed_instruction() {
+  fn cancel_order_lever_to_stable_exo_returns_well_formed_instruction() {
     let owner = Pubkey::new_unique();
     let order = Pubkey::new_unique();
     let collateral_mint = Pubkey::new_unique();
-    let ix = cancel_order_l2s_exo(
+    let ix = cancel_order_lever_to_stable_exo(
       owner,
       order,
       collateral_mint,
-      &args::CancelOrderL2sExo {},
+      &args::CancelOrderLeverToStableExo {},
     );
     assert_eq!(ix.program_id, trigger_orders::ID);
     assert_eq!(ix.data.len(), 8);

--- a/hylo-idl/src/instruction_builders/trigger_orders.rs
+++ b/hylo-idl/src/instruction_builders/trigger_orders.rs
@@ -1,0 +1,450 @@
+//! Instruction builders for `hylo-trigger-orders`.
+
+use anchor_lang::prelude::Pubkey;
+use anchor_lang::solana_program::instruction::Instruction;
+use anchor_lang::{InstructionData, ToAccountMetas};
+
+use crate::exchange::accounts::{ExoPair, Hylo};
+use crate::trigger_orders;
+use crate::trigger_orders::account_builders;
+use crate::trigger_orders::client::args;
+
+#[must_use]
+pub fn create_order_s2l_lst(
+  owner: Pubkey,
+  order: Pubkey,
+  args: &args::CreateOrderS2lLst,
+) -> Instruction {
+  let accounts = account_builders::create_order_s2l_lst(owner, order);
+  Instruction {
+    program_id: trigger_orders::ID,
+    accounts: accounts.to_account_metas(None),
+    data: args.data(),
+  }
+}
+
+#[must_use]
+pub fn create_order_s2l_exo(
+  owner: Pubkey,
+  order: Pubkey,
+  collateral_mint: Pubkey,
+  args: &args::CreateOrderS2lExo,
+) -> Instruction {
+  let accounts =
+    account_builders::create_order_s2l_exo(owner, order, collateral_mint);
+  Instruction {
+    program_id: trigger_orders::ID,
+    accounts: accounts.to_account_metas(None),
+    data: args.data(),
+  }
+}
+
+#[must_use]
+pub fn create_order_l2s_lst(
+  owner: Pubkey,
+  order: Pubkey,
+  args: &args::CreateOrderL2sLst,
+) -> Instruction {
+  let accounts = account_builders::create_order_l2s_lst(owner, order);
+  Instruction {
+    program_id: trigger_orders::ID,
+    accounts: accounts.to_account_metas(None),
+    data: args.data(),
+  }
+}
+
+#[must_use]
+pub fn create_order_l2s_exo(
+  owner: Pubkey,
+  order: Pubkey,
+  collateral_mint: Pubkey,
+  args: &args::CreateOrderL2sExo,
+) -> Instruction {
+  let accounts =
+    account_builders::create_order_l2s_exo(owner, order, collateral_mint);
+  Instruction {
+    program_id: trigger_orders::ID,
+    accounts: accounts.to_account_metas(None),
+    data: args.data(),
+  }
+}
+
+#[must_use]
+pub fn execute_order_s2l_lst(
+  executor: Pubkey,
+  owner: Pubkey,
+  order: Pubkey,
+  hylo: &Hylo,
+) -> Instruction {
+  let accounts =
+    account_builders::execute_order_s2l_lst(executor, owner, order, hylo);
+  Instruction {
+    program_id: trigger_orders::ID,
+    accounts: accounts.to_account_metas(None),
+    data: args::ExecuteOrderS2lLst {}.data(),
+  }
+}
+
+#[must_use]
+pub fn execute_order_l2s_lst(
+  executor: Pubkey,
+  owner: Pubkey,
+  order: Pubkey,
+  hylo: &Hylo,
+) -> Instruction {
+  let accounts =
+    account_builders::execute_order_l2s_lst(executor, owner, order, hylo);
+  Instruction {
+    program_id: trigger_orders::ID,
+    accounts: accounts.to_account_metas(None),
+    data: args::ExecuteOrderL2sLst {}.data(),
+  }
+}
+
+#[must_use]
+pub fn execute_order_s2l_exo(
+  executor: Pubkey,
+  owner: Pubkey,
+  order: Pubkey,
+  collateral_mint: Pubkey,
+  hylo: &Hylo,
+  exo_pair: &ExoPair,
+) -> Instruction {
+  let accounts = account_builders::execute_order_s2l_exo(
+    executor,
+    owner,
+    order,
+    collateral_mint,
+    hylo,
+    exo_pair,
+  );
+  Instruction {
+    program_id: trigger_orders::ID,
+    accounts: accounts.to_account_metas(None),
+    data: args::ExecuteOrderS2lExo {}.data(),
+  }
+}
+
+#[must_use]
+pub fn execute_order_l2s_exo(
+  executor: Pubkey,
+  owner: Pubkey,
+  order: Pubkey,
+  collateral_mint: Pubkey,
+  hylo: &Hylo,
+  exo_pair: &ExoPair,
+) -> Instruction {
+  let accounts = account_builders::execute_order_l2s_exo(
+    executor,
+    owner,
+    order,
+    collateral_mint,
+    hylo,
+    exo_pair,
+  );
+  Instruction {
+    program_id: trigger_orders::ID,
+    accounts: accounts.to_account_metas(None),
+    data: args::ExecuteOrderL2sExo {}.data(),
+  }
+}
+
+#[must_use]
+pub fn cancel_order_s2l(
+  owner: Pubkey,
+  order: Pubkey,
+  args: &args::CancelOrderS2l,
+) -> Instruction {
+  let accounts = account_builders::cancel_order_s2l(owner, order);
+  Instruction {
+    program_id: trigger_orders::ID,
+    accounts: accounts.to_account_metas(None),
+    data: args.data(),
+  }
+}
+
+#[must_use]
+pub fn cancel_order_l2s_lst(
+  owner: Pubkey,
+  order: Pubkey,
+  args: &args::CancelOrderL2sLst,
+) -> Instruction {
+  let accounts = account_builders::cancel_order_l2s_lst(owner, order);
+  Instruction {
+    program_id: trigger_orders::ID,
+    accounts: accounts.to_account_metas(None),
+    data: args.data(),
+  }
+}
+
+#[must_use]
+pub fn cancel_order_l2s_exo(
+  owner: Pubkey,
+  order: Pubkey,
+  collateral_mint: Pubkey,
+  args: &args::CancelOrderL2sExo,
+) -> Instruction {
+  let accounts =
+    account_builders::cancel_order_l2s_exo(owner, order, collateral_mint);
+  Instruction {
+    program_id: trigger_orders::ID,
+    accounts: accounts.to_account_metas(None),
+    data: args.data(),
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::exchange::types::{
+    BorrowRateConfig, HarvestCache, LevercoinFees, PoolDrawdown,
+    RebalanceCurveConfig, UFixValue64, VirtualStablecoin,
+  };
+  use crate::trigger_orders::types::TriggerDirection;
+
+  fn create_args_l2s_lst() -> args::CreateOrderL2sLst {
+    args::CreateOrderL2sLst {
+      nonce: 42,
+      escrow_amount: 1000,
+      trigger_price: 100,
+      trigger_expo: -8,
+      direction: TriggerDirection::AtOrAbove,
+    }
+  }
+
+  fn create_args_l2s_exo() -> args::CreateOrderL2sExo {
+    args::CreateOrderL2sExo {
+      nonce: 42,
+      escrow_amount: 1000,
+      trigger_price: 100,
+      trigger_expo: -8,
+      direction: TriggerDirection::AtOrAbove,
+    }
+  }
+
+  fn create_args_s2l_exo() -> args::CreateOrderS2lExo {
+    args::CreateOrderS2lExo {
+      nonce: 42,
+      escrow_amount: 1000,
+      trigger_price: 100,
+      trigger_expo: -8,
+      direction: TriggerDirection::AtOrAbove,
+    }
+  }
+
+  fn healthy_hylo_min() -> Hylo {
+    Hylo::default()
+  }
+
+  // `ExoPair` does NOT derive `Default`, so list every field explicitly. The
+  // execute builders only read `exo_pair.oracle`, set explicitly by callers.
+  fn healthy_exo_pair_min() -> ExoPair {
+    ExoPair {
+      collateral_mint: Pubkey::new_unique(),
+      levercoin_mint_bump: 0,
+      levercoin_auth_bump: 0,
+      vault_auth_bump: 0,
+      fee_auth_bump: 0,
+      oracle: Pubkey::new_unique(),
+      oracle_feed_id: [0u8; 32],
+      oracle_interval_secs: 30,
+      oracle_conf_tolerance: UFixValue64::default(),
+      stablecoin_mint_threshold: UFixValue64::default(),
+      virtual_stablecoin: VirtualStablecoin::default(),
+      borrow_rate_config: BorrowRateConfig::default(),
+      borrow_rate_harvest_cache: HarvestCache::default(),
+      levercoin_fees: LevercoinFees::default(),
+      sell_curve_config: RebalanceCurveConfig::default(),
+      buy_curve_config: RebalanceCurveConfig::default(),
+      rebalance_deviation_tolerance: UFixValue64::default(),
+      paused: false,
+      levercoin_market_cap_limit: UFixValue64::default(),
+      pool_drawdown: PoolDrawdown::default(),
+      _reserved: [0u8; 100],
+    }
+  }
+
+  #[test]
+  fn create_order_s2l_lst_returns_well_formed_instruction() {
+    let owner = Pubkey::new_unique();
+    let order = Pubkey::new_unique();
+    let args = args::CreateOrderS2lLst {
+      nonce: 42,
+      escrow_amount: 1000,
+      trigger_price: 100,
+      trigger_expo: -8,
+      direction: TriggerDirection::AtOrAbove,
+    };
+    let ix = create_order_s2l_lst(owner, order, &args);
+    assert_eq!(ix.program_id, trigger_orders::ID);
+    // Anchor: 8-byte discriminator + borsh args.
+    // 8 + 8(nonce u64) + 8(escrow u64) + 8(trigger_price i64) + 4(expo i32)
+    //   + 1(direction) = 37.
+    assert_eq!(ix.data.len(), 37);
+    assert_eq!(ix.accounts.len(), 11);
+    assert_eq!(ix.accounts[0].pubkey, owner);
+    assert!(ix.accounts[0].is_signer);
+    assert!(ix.accounts[0].is_writable);
+    assert_eq!(ix.accounts[1].pubkey, order);
+  }
+
+  #[test]
+  fn create_order_s2l_exo_returns_well_formed_instruction() {
+    let owner = Pubkey::new_unique();
+    let order = Pubkey::new_unique();
+    let collateral_mint = Pubkey::new_unique();
+    let ix = create_order_s2l_exo(
+      owner,
+      order,
+      collateral_mint,
+      &create_args_s2l_exo(),
+    );
+    assert_eq!(ix.program_id, trigger_orders::ID);
+    assert_eq!(ix.data.len(), 37);
+    assert_eq!(ix.accounts.len(), 12);
+    assert_eq!(ix.accounts[0].pubkey, owner);
+    assert_eq!(ix.accounts[1].pubkey, order);
+  }
+
+  #[test]
+  fn create_order_l2s_lst_returns_well_formed_instruction() {
+    let owner = Pubkey::new_unique();
+    let order = Pubkey::new_unique();
+    let ix = create_order_l2s_lst(owner, order, &create_args_l2s_lst());
+    assert_eq!(ix.program_id, trigger_orders::ID);
+    assert_eq!(ix.data.len(), 37);
+    assert_eq!(ix.accounts.len(), 11);
+    assert_eq!(ix.accounts[0].pubkey, owner);
+    assert_eq!(ix.accounts[1].pubkey, order);
+  }
+
+  #[test]
+  fn create_order_l2s_exo_returns_well_formed_instruction() {
+    let owner = Pubkey::new_unique();
+    let order = Pubkey::new_unique();
+    let collateral_mint = Pubkey::new_unique();
+    let ix = create_order_l2s_exo(
+      owner,
+      order,
+      collateral_mint,
+      &create_args_l2s_exo(),
+    );
+    assert_eq!(ix.program_id, trigger_orders::ID);
+    assert_eq!(ix.data.len(), 37);
+    assert_eq!(ix.accounts.len(), 12);
+    assert_eq!(ix.accounts[0].pubkey, owner);
+    assert_eq!(ix.accounts[1].pubkey, order);
+  }
+
+  #[test]
+  fn execute_order_s2l_lst_returns_well_formed_instruction() {
+    let executor = Pubkey::new_unique();
+    let owner = Pubkey::new_unique();
+    let order = Pubkey::new_unique();
+    let hylo = healthy_hylo_min();
+    let ix = execute_order_s2l_lst(executor, owner, order, &hylo);
+    assert_eq!(ix.program_id, trigger_orders::ID);
+    assert_eq!(ix.data.len(), 8);
+    assert_eq!(ix.accounts.len(), 21);
+    assert_eq!(ix.accounts[0].pubkey, executor);
+  }
+
+  #[test]
+  fn execute_order_l2s_lst_returns_well_formed_instruction() {
+    let executor = Pubkey::new_unique();
+    let owner = Pubkey::new_unique();
+    let order = Pubkey::new_unique();
+    let hylo = healthy_hylo_min();
+    let ix = execute_order_l2s_lst(executor, owner, order, &hylo);
+    assert_eq!(ix.program_id, trigger_orders::ID);
+    assert_eq!(ix.data.len(), 8);
+    assert_eq!(ix.accounts.len(), 21);
+    assert_eq!(ix.accounts[0].pubkey, executor);
+  }
+
+  #[test]
+  fn execute_order_s2l_exo_returns_well_formed_instruction() {
+    let executor = Pubkey::new_unique();
+    let owner = Pubkey::new_unique();
+    let order = Pubkey::new_unique();
+    let collateral_mint = Pubkey::new_unique();
+    let hylo = healthy_hylo_min();
+    let exo_pair = healthy_exo_pair_min();
+    let ix = execute_order_s2l_exo(
+      executor,
+      owner,
+      order,
+      collateral_mint,
+      &hylo,
+      &exo_pair,
+    );
+    assert_eq!(ix.program_id, trigger_orders::ID);
+    assert_eq!(ix.data.len(), 8);
+    assert_eq!(ix.accounts.len(), 25);
+    assert_eq!(ix.accounts[0].pubkey, executor);
+  }
+
+  #[test]
+  fn execute_order_l2s_exo_returns_well_formed_instruction() {
+    let executor = Pubkey::new_unique();
+    let owner = Pubkey::new_unique();
+    let order = Pubkey::new_unique();
+    let collateral_mint = Pubkey::new_unique();
+    let hylo = healthy_hylo_min();
+    let exo_pair = healthy_exo_pair_min();
+    let ix = execute_order_l2s_exo(
+      executor,
+      owner,
+      order,
+      collateral_mint,
+      &hylo,
+      &exo_pair,
+    );
+    assert_eq!(ix.program_id, trigger_orders::ID);
+    assert_eq!(ix.data.len(), 8);
+    assert_eq!(ix.accounts.len(), 25);
+    assert_eq!(ix.accounts[0].pubkey, executor);
+  }
+
+  #[test]
+  fn cancel_order_s2l_returns_well_formed_instruction() {
+    let owner = Pubkey::new_unique();
+    let order = Pubkey::new_unique();
+    let ix = cancel_order_s2l(owner, order, &args::CancelOrderS2l {});
+    assert_eq!(ix.program_id, trigger_orders::ID);
+    assert_eq!(ix.data.len(), 8);
+    assert_eq!(ix.accounts.len(), 8);
+    assert_eq!(ix.accounts[0].pubkey, owner);
+    assert_eq!(ix.accounts[1].pubkey, order);
+  }
+
+  #[test]
+  fn cancel_order_l2s_lst_returns_well_formed_instruction() {
+    let owner = Pubkey::new_unique();
+    let order = Pubkey::new_unique();
+    let ix = cancel_order_l2s_lst(owner, order, &args::CancelOrderL2sLst {});
+    assert_eq!(ix.program_id, trigger_orders::ID);
+    assert_eq!(ix.data.len(), 8);
+    assert_eq!(ix.accounts.len(), 8);
+    assert_eq!(ix.accounts[0].pubkey, owner);
+    assert_eq!(ix.accounts[1].pubkey, order);
+  }
+
+  #[test]
+  fn cancel_order_l2s_exo_returns_well_formed_instruction() {
+    let owner = Pubkey::new_unique();
+    let order = Pubkey::new_unique();
+    let collateral_mint = Pubkey::new_unique();
+    let ix = cancel_order_l2s_exo(
+      owner,
+      order,
+      collateral_mint,
+      &args::CancelOrderL2sExo {},
+    );
+    assert_eq!(ix.program_id, trigger_orders::ID);
+    assert_eq!(ix.data.len(), 8);
+    assert_eq!(ix.accounts.len(), 9);
+    assert_eq!(ix.accounts[0].pubkey, owner);
+    assert_eq!(ix.accounts[1].pubkey, order);
+  }
+}

--- a/hylo-idl/src/lib.rs
+++ b/hylo-idl/src/lib.rs
@@ -123,7 +123,8 @@ mod trigger_orders_smoke_tests {
   // adjust `pub mod trigger_orders { ... }` in lib.rs accordingly.
   #[allow(unused_imports)]
   use crate::trigger_orders::events::{
-    TriggerOrderCancelled, TriggerOrderCreated, TriggerOrderFilled,
+    TriggerOrderCancelledEvent, TriggerOrderCreatedEvent,
+    TriggerOrderFilledEvent,
   };
 
   #[test]

--- a/hylo-idl/src/lib.rs
+++ b/hylo-idl/src/lib.rs
@@ -61,6 +61,7 @@ pub mod trigger_orders {
   #[cfg(feature = "shadow")]
   pub use super::codegen::hylo_trigger_orders_shadow::*;
   pub use super::instruction_builders::trigger_orders as instruction_builders;
+  pub use super::trigger_orders_ext::{ExecutabilityBlocker, TriggerOutcome};
 }
 
 mod trigger_orders_ext;

--- a/hylo-idl/src/lib.rs
+++ b/hylo-idl/src/lib.rs
@@ -56,11 +56,11 @@ pub mod router {
 
 pub mod trigger_orders {
   pub use super::account_builders::trigger_orders as account_builders;
-  // `instruction_builders` module added in later tasks.
   #[cfg(not(feature = "shadow"))]
   pub use super::codegen::hylo_trigger_orders::*;
   #[cfg(feature = "shadow")]
   pub use super::codegen::hylo_trigger_orders_shadow::*;
+  pub use super::instruction_builders::trigger_orders as instruction_builders;
 }
 
 mod trigger_orders_ext;

--- a/hylo-idl/src/lib.rs
+++ b/hylo-idl/src/lib.rs
@@ -55,7 +55,8 @@ pub mod router {
 }
 
 pub mod trigger_orders {
-  // `account_builders` and `instruction_builders` modules added in later tasks.
+  pub use super::account_builders::trigger_orders as account_builders;
+  // `instruction_builders` module added in later tasks.
   #[cfg(not(feature = "shadow"))]
   pub use super::codegen::hylo_trigger_orders::*;
   #[cfg(feature = "shadow")]

--- a/hylo-idl/src/lib.rs
+++ b/hylo-idl/src/lib.rs
@@ -9,12 +9,16 @@ mod codegen {
   anchor_lang::declare_program!(hylo_exchange);
   #[cfg(not(feature = "shadow"))]
   anchor_lang::declare_program!(hylo_router);
+  #[cfg(not(feature = "shadow"))]
+  anchor_lang::declare_program!(hylo_trigger_orders);
   #[cfg(feature = "shadow")]
   anchor_lang::declare_program!(hylo_earn_pool_shadow);
   #[cfg(feature = "shadow")]
   anchor_lang::declare_program!(hylo_exchange_shadow);
   #[cfg(feature = "shadow")]
   anchor_lang::declare_program!(hylo_router_shadow);
+  #[cfg(feature = "shadow")]
+  anchor_lang::declare_program!(hylo_trigger_orders_shadow);
 }
 
 pub mod pda;
@@ -50,12 +54,20 @@ pub mod router {
   pub use super::instruction_builders::router as instruction_builders;
 }
 
+pub mod trigger_orders {
+  // `account_builders` and `instruction_builders` modules added in later tasks.
+  #[cfg(not(feature = "shadow"))]
+  pub use super::codegen::hylo_trigger_orders::*;
+  #[cfg(feature = "shadow")]
+  pub use super::codegen::hylo_trigger_orders_shadow::*;
+}
+
 #[cfg(test)]
 mod tests {
   use anchor_lang::prelude::{pubkey, Pubkey};
   use anchor_lang::Id;
 
-  use crate::{earn_pool, exchange, router};
+  use crate::{earn_pool, exchange, router, trigger_orders};
 
   #[cfg(not(feature = "shadow"))]
   mod expected {
@@ -66,6 +78,8 @@ mod tests {
       pubkey!("HYEXCHtHkBagdStcJCp3xbbb9B7sdMdWXFNj6mdsG4hn");
     pub const ROUTER: Pubkey =
       pubkey!("hyRouTRDAgn65xyyJ3L5c4k5SFmSdr3NxDV8Euzjy3f");
+    pub const TRIGGER_ORDERS: Pubkey =
+      pubkey!("2GbKbBumaPjHsJ5qzkUt6cnsyTBT6aPNj3gq2mvocpFW");
   }
 
   #[cfg(feature = "shadow")]
@@ -77,6 +91,8 @@ mod tests {
       pubkey!("HYSheX1FkQgYvzUsyPEuzXrGp2tNAWMvbuNVFETXGAXH");
     pub const ROUTER: Pubkey =
       pubkey!("hyshRoSsynsCxF5Dt9KnHc5pS1u8saVT79NywtWUSsv");
+    pub const TRIGGER_ORDERS: Pubkey =
+      pubkey!("4tgWjqeTdwjCrvHStnR5dzW8WGADRyAy7jkS32zNnJuM");
   }
 
   #[test]
@@ -84,6 +100,7 @@ mod tests {
     assert_eq!(earn_pool::ID, expected::EARN_POOL);
     assert_eq!(exchange::ID, expected::EXCHANGE);
     assert_eq!(router::ID, expected::ROUTER);
+    assert_eq!(trigger_orders::ID, expected::TRIGGER_ORDERS);
   }
 
   #[test]
@@ -91,5 +108,41 @@ mod tests {
     assert_eq!(earn_pool::program::HyloEarnPool::id(), expected::EARN_POOL);
     assert_eq!(exchange::program::HyloExchange::id(), expected::EXCHANGE);
     assert_eq!(router::program::HyloRouter::id(), expected::ROUTER);
+  }
+}
+
+#[cfg(test)]
+mod trigger_orders_smoke_tests {
+  // Confirm the generated events module is reachable. Task 17 depends on
+  // this path resolving; an unresolved path here is a hard compile error.
+  // If the macro generates events under a different sub-module name,
+  // adjust `pub mod trigger_orders { ... }` in lib.rs accordingly.
+  #[allow(unused_imports)]
+  use crate::trigger_orders::events::{
+    TriggerOrderCancelled, TriggerOrderCreated, TriggerOrderFilled,
+  };
+
+  #[test]
+  fn tip_constant_resolves() {
+    let tip: u64 = crate::trigger_orders::constants::EXECUTOR_TIP_LAMPORTS;
+    assert_eq!(tip, 5_000_000);
+  }
+
+  /// PDA derived locally must equal the value recorded on the deployed
+  /// shadow program. Locks the seed + program-ID pair against silent
+  /// regressions in either repo.
+  #[cfg(feature = "shadow")]
+  #[test]
+  fn shadow_event_authority_matches_deployed() {
+    use anchor_lang::prelude::Pubkey;
+
+    let (pda, _bump) = Pubkey::find_program_address(
+      &[b"__event_authority"],
+      &crate::trigger_orders::ID,
+    );
+    let recorded: Pubkey = "32Sig6DM39gxcVqDWM666ts3auNwjRpXuazUEhyqWP63"
+      .parse()
+      .unwrap();
+    assert_eq!(pda, recorded);
   }
 }

--- a/hylo-idl/src/lib.rs
+++ b/hylo-idl/src/lib.rs
@@ -62,6 +62,8 @@ pub mod trigger_orders {
   pub use super::codegen::hylo_trigger_orders_shadow::*;
 }
 
+mod trigger_orders_ext;
+
 #[cfg(test)]
 mod tests {
   use anchor_lang::prelude::{pubkey, Pubkey};

--- a/hylo-idl/src/pda.rs
+++ b/hylo-idl/src/pda.rs
@@ -235,3 +235,122 @@ pub const EARN_POOL_EVENT_AUTHORITY: Pubkey = event_auth(earn_pool::ID);
 
 pub const USDC_PAIR: Pubkey =
   pda!(exchange::ID, exchange::constants::USDC_PAIR);
+
+use crate::trigger_orders::types::{ConvertDirection, PairTarget};
+
+/// Seed for `TriggerOrder` PDAs — byte-equal to `hylo_trigger_orders::ORDER`.
+pub const TRIGGER_ORDER: &[u8; 5] = b"order";
+
+/// PDA for an LST trigger order (s2l or l2s).
+#[must_use]
+pub fn trigger_order_lst(
+  owner: Pubkey,
+  direction: ConvertDirection,
+  nonce: u64,
+) -> (Pubkey, u8) {
+  Pubkey::find_program_address(
+    &[
+      TRIGGER_ORDER,
+      owner.as_ref(),
+      &[direction.tag_byte()],
+      &[PairTarget::LST_TAG],
+      &nonce.to_le_bytes(),
+    ],
+    &crate::trigger_orders::ID,
+  )
+}
+
+/// PDA for an EXO trigger order (s2l or l2s).
+#[must_use]
+pub fn trigger_order_exo(
+  owner: Pubkey,
+  direction: ConvertDirection,
+  collateral_mint: Pubkey,
+  nonce: u64,
+) -> (Pubkey, u8) {
+  Pubkey::find_program_address(
+    &[
+      TRIGGER_ORDER,
+      owner.as_ref(),
+      &[direction.tag_byte()],
+      &[PairTarget::EXO_TAG],
+      collateral_mint.as_ref(),
+      &nonce.to_le_bytes(),
+    ],
+    &crate::trigger_orders::ID,
+  )
+}
+
+/// `__event_authority` PDA for the trigger-orders program.
+#[must_use]
+pub fn trigger_orders_event_authority() -> Pubkey {
+  Pubkey::find_program_address(
+    &[b"__event_authority"],
+    &crate::trigger_orders::ID,
+  )
+  .0
+}
+
+#[cfg(test)]
+mod trigger_orders_pda_tests {
+  use anchor_lang::prelude::Pubkey;
+
+  use super::*;
+  use crate::trigger_orders::types::{ConvertDirection, PairTarget};
+
+  #[test]
+  fn lst_pda_seeds_round_trip() {
+    let owner = Pubkey::new_unique();
+    let (pda, _bump) =
+      trigger_order_lst(owner, ConvertDirection::StableToLever, 42);
+    let (expected, _) = Pubkey::find_program_address(
+      &[
+        TRIGGER_ORDER,
+        owner.as_ref(),
+        &[ConvertDirection::S2L_TAG],
+        &[PairTarget::LST_TAG],
+        &42u64.to_le_bytes(),
+      ],
+      &crate::trigger_orders::ID,
+    );
+    assert_eq!(pda, expected);
+  }
+
+  #[test]
+  fn exo_pda_seeds_include_collateral_mint() {
+    let owner = Pubkey::new_unique();
+    let mint = Pubkey::new_unique();
+    let (pda, _bump) =
+      trigger_order_exo(owner, ConvertDirection::LeverToStable, mint, 7);
+    let (expected, _) = Pubkey::find_program_address(
+      &[
+        TRIGGER_ORDER,
+        owner.as_ref(),
+        &[ConvertDirection::L2S_TAG],
+        &[PairTarget::EXO_TAG],
+        mint.as_ref(),
+        &7u64.to_le_bytes(),
+      ],
+      &crate::trigger_orders::ID,
+    );
+    assert_eq!(pda, expected);
+  }
+
+  #[test]
+  fn lst_and_exo_pdas_disjoint_at_same_owner_nonce() {
+    let owner = Pubkey::new_unique();
+    let mint = Pubkey::new_unique();
+    let (lst, _) = trigger_order_lst(owner, ConvertDirection::StableToLever, 1);
+    let (exo, _) =
+      trigger_order_exo(owner, ConvertDirection::StableToLever, mint, 1);
+    assert_ne!(lst, exo, "PDA-tag separation broken");
+  }
+
+  #[test]
+  fn s2l_and_l2s_pdas_disjoint_at_same_owner_pair_nonce() {
+    let owner = Pubkey::new_unique();
+    let (s2l, _) = trigger_order_lst(owner, ConvertDirection::StableToLever, 1);
+    let (l2s, _) = trigger_order_lst(owner, ConvertDirection::LeverToStable, 1);
+    assert_ne!(s2l, l2s, "direction-tag separation broken");
+  }
+}

--- a/hylo-idl/src/pda.rs
+++ b/hylo-idl/src/pda.rs
@@ -241,7 +241,7 @@ use crate::trigger_orders::types::{ConvertDirection, PairTarget};
 /// Seed for `TriggerOrder` PDAs — byte-equal to `hylo_trigger_orders::ORDER`.
 pub const TRIGGER_ORDER: &[u8; 5] = b"order";
 
-/// PDA for an LST trigger order (s2l or l2s).
+/// PDA for an LST trigger order (stable-to-lever or lever-to-stable).
 #[must_use]
 pub fn trigger_order_lst(
   owner: Pubkey,
@@ -260,7 +260,7 @@ pub fn trigger_order_lst(
   )
 }
 
-/// PDA for an EXO trigger order (s2l or l2s).
+/// PDA for an EXO trigger order (stable-to-lever or lever-to-stable).
 #[must_use]
 pub fn trigger_order_exo(
   owner: Pubkey,
@@ -307,7 +307,7 @@ mod trigger_orders_pda_tests {
       &[
         TRIGGER_ORDER,
         owner.as_ref(),
-        &[ConvertDirection::S2L_TAG],
+        &[ConvertDirection::STABLE_TO_LEVER_TAG],
         &[PairTarget::LST_TAG],
         &42u64.to_le_bytes(),
       ],
@@ -326,7 +326,7 @@ mod trigger_orders_pda_tests {
       &[
         TRIGGER_ORDER,
         owner.as_ref(),
-        &[ConvertDirection::L2S_TAG],
+        &[ConvertDirection::LEVER_TO_STABLE_TAG],
         &[PairTarget::EXO_TAG],
         mint.as_ref(),
         &7u64.to_le_bytes(),
@@ -347,10 +347,16 @@ mod trigger_orders_pda_tests {
   }
 
   #[test]
-  fn s2l_and_l2s_pdas_disjoint_at_same_owner_pair_nonce() {
+  fn stable_to_lever_and_lever_to_stable_pdas_disjoint_at_same_owner_pair_nonce(
+  ) {
     let owner = Pubkey::new_unique();
-    let (s2l, _) = trigger_order_lst(owner, ConvertDirection::StableToLever, 1);
-    let (l2s, _) = trigger_order_lst(owner, ConvertDirection::LeverToStable, 1);
-    assert_ne!(s2l, l2s, "direction-tag separation broken");
+    let (stable_to_lever, _) =
+      trigger_order_lst(owner, ConvertDirection::StableToLever, 1);
+    let (lever_to_stable, _) =
+      trigger_order_lst(owner, ConvertDirection::LeverToStable, 1);
+    assert_ne!(
+      stable_to_lever, lever_to_stable,
+      "direction-tag separation broken"
+    );
   }
 }

--- a/hylo-idl/src/trigger_orders_ext.rs
+++ b/hylo-idl/src/trigger_orders_ext.rs
@@ -1,0 +1,67 @@
+//! Hand-written extensions on `declare_program!`-generated trigger-orders
+//! types. Lives in `hylo-idl` because Rust's orphan rule forbids `impl`s
+//! on generated types from a foreign crate.
+
+use crate::trigger_orders::types::{ConvertDirection, PairTarget};
+
+impl ConvertDirection {
+  /// PDA seed-slice tag for `StableToLever` orders. Must match
+  /// `hylo_trigger_orders::state::ConvertDirection::S2L_TAG`.
+  pub const S2L_TAG: u8 = 0;
+  /// PDA seed-slice tag for `LeverToStable` orders. Must match
+  /// `hylo_trigger_orders::state::ConvertDirection::L2S_TAG`.
+  pub const L2S_TAG: u8 = 1;
+
+  #[must_use]
+  pub const fn tag_byte(&self) -> u8 {
+    match self {
+      Self::StableToLever => Self::S2L_TAG,
+      Self::LeverToStable => Self::L2S_TAG,
+    }
+  }
+}
+
+impl PairTarget {
+  /// PDA seed-slice tag for the `Lst` variant. Must match
+  /// `hylo_trigger_orders::state::PairTarget::LST_TAG`.
+  pub const LST_TAG: u8 = 0;
+  /// PDA seed-slice tag for the `Exo` variant. Must match
+  /// `hylo_trigger_orders::state::PairTarget::EXO_TAG`.
+  pub const EXO_TAG: u8 = 1;
+
+  #[must_use]
+  pub const fn tag_byte(&self) -> u8 {
+    match self {
+      Self::Lst => Self::LST_TAG,
+      Self::Exo { .. } => Self::EXO_TAG,
+    }
+  }
+}
+
+#[cfg(test)]
+mod tag_tests {
+  use super::*;
+
+  #[test]
+  fn convert_direction_tags() {
+    assert_eq!(ConvertDirection::S2L_TAG, 0);
+    assert_eq!(ConvertDirection::L2S_TAG, 1);
+    assert_eq!(ConvertDirection::StableToLever.tag_byte(), 0);
+    assert_eq!(ConvertDirection::LeverToStable.tag_byte(), 1);
+  }
+
+  #[test]
+  fn pair_target_tags() {
+    use anchor_lang::prelude::Pubkey;
+    assert_eq!(PairTarget::LST_TAG, 0);
+    assert_eq!(PairTarget::EXO_TAG, 1);
+    assert_eq!(PairTarget::Lst.tag_byte(), 0);
+    assert_eq!(
+      PairTarget::Exo {
+        collateral_mint: Pubkey::new_unique()
+      }
+      .tag_byte(),
+      1
+    );
+  }
+}

--- a/hylo-idl/src/trigger_orders_ext.rs
+++ b/hylo-idl/src/trigger_orders_ext.rs
@@ -58,17 +58,17 @@ impl TriggerOrder {
 
 impl ConvertDirection {
   /// PDA seed-slice tag for `StableToLever` orders. Must match
-  /// `hylo_trigger_orders::state::ConvertDirection::S2L_TAG`.
-  pub const S2L_TAG: u8 = 0;
+  /// `hylo_trigger_orders::state::ConvertDirection::STABLE_TO_LEVER_TAG`.
+  pub const STABLE_TO_LEVER_TAG: u8 = 0;
   /// PDA seed-slice tag for `LeverToStable` orders. Must match
-  /// `hylo_trigger_orders::state::ConvertDirection::L2S_TAG`.
-  pub const L2S_TAG: u8 = 1;
+  /// `hylo_trigger_orders::state::ConvertDirection::LEVER_TO_STABLE_TAG`.
+  pub const LEVER_TO_STABLE_TAG: u8 = 1;
 
   #[must_use]
   pub const fn tag_byte(&self) -> u8 {
     match self {
-      Self::StableToLever => Self::S2L_TAG,
-      Self::LeverToStable => Self::L2S_TAG,
+      Self::StableToLever => Self::STABLE_TO_LEVER_TAG,
+      Self::LeverToStable => Self::LEVER_TO_STABLE_TAG,
     }
   }
 }
@@ -212,7 +212,7 @@ mod can_execute_tests {
 
   // `TriggerOrder` intentionally does NOT derive `Default`, so this fixture
   // lists every field explicitly — adding a field forces it to be updated.
-  fn lst_order_s2l_at_above_trigger() -> TriggerOrder {
+  fn lst_order_stable_to_lever_at_above_trigger() -> TriggerOrder {
     TriggerOrder {
       owner: Pubkey::default(),
       pair_target: PairTarget::Lst,
@@ -224,14 +224,15 @@ mod can_execute_tests {
       direction: TriggerDirection::AtOrAbove,
       created_at: 0,
       bump: 0,
+      _reserved: [0u8; 64],
     }
   }
 
   // An `Exo`-variant order at-or-above its trigger. Clones the LST fixture
   // and swaps the pair target so the EXO code paths in `can_execute` are
   // exercised. (`TriggerOrder` is `Copy`, so the clone is a plain reassign.)
-  fn exo_order_s2l_at_above_trigger() -> TriggerOrder {
-    let mut order = lst_order_s2l_at_above_trigger();
+  fn exo_order_stable_to_lever_at_above_trigger() -> TriggerOrder {
+    let mut order = lst_order_stable_to_lever_at_above_trigger();
     order.pair_target = PairTarget::Exo {
       collateral_mint: Pubkey::new_unique(),
     };
@@ -300,14 +301,14 @@ mod can_execute_tests {
 
   #[test]
   fn met_and_healthy_returns_ok() {
-    let order = lst_order_s2l_at_above_trigger();
+    let order = lst_order_stable_to_lever_at_above_trigger();
     let hylo = healthy_hylo(978);
     assert!(order.can_execute(&hylo, None, 150, -8, 978).is_ok());
   }
 
   #[test]
   fn trigger_not_met_returns_trigger_not_met() {
-    let order = lst_order_s2l_at_above_trigger();
+    let order = lst_order_stable_to_lever_at_above_trigger();
     let hylo = healthy_hylo(978);
     assert_eq!(
       order.can_execute(&hylo, None, 50, -8, 978),
@@ -317,7 +318,7 @@ mod can_execute_tests {
 
   #[test]
   fn expo_mismatch_returns_expo_mismatch() {
-    let order = lst_order_s2l_at_above_trigger();
+    let order = lst_order_stable_to_lever_at_above_trigger();
     let hylo = healthy_hylo(978);
     assert_eq!(
       order.can_execute(&hylo, None, 150, -6, 978),
@@ -327,7 +328,7 @@ mod can_execute_tests {
 
   #[test]
   fn protocol_paused_returns_protocol_paused() {
-    let order = lst_order_s2l_at_above_trigger();
+    let order = lst_order_stable_to_lever_at_above_trigger();
     let mut hylo = healthy_hylo(978);
     hylo.protocol_paused = true;
     assert_eq!(
@@ -338,7 +339,7 @@ mod can_execute_tests {
 
   #[test]
   fn lst_pair_paused_returns_lst_pair_paused() {
-    let order = lst_order_s2l_at_above_trigger();
+    let order = lst_order_stable_to_lever_at_above_trigger();
     let mut hylo = healthy_hylo(978);
     hylo.lst_pair_paused = true;
     assert_eq!(
@@ -349,7 +350,7 @@ mod can_execute_tests {
 
   #[test]
   fn drawdown_outstanding_returns_drawdown_not_repaid() {
-    let order = lst_order_s2l_at_above_trigger();
+    let order = lst_order_stable_to_lever_at_above_trigger();
     let mut hylo = healthy_hylo(978);
     hylo.pool_drawdown.ledger.supply.bits = 1;
     assert_eq!(
@@ -360,7 +361,7 @@ mod can_execute_tests {
 
   #[test]
   fn yield_harvest_stale_returns_stale() {
-    let order = lst_order_s2l_at_above_trigger();
+    let order = lst_order_stable_to_lever_at_above_trigger();
     let hylo = healthy_hylo(977); // one epoch behind
     assert_eq!(
       order.can_execute(&hylo, None, 150, -8, 978),
@@ -370,7 +371,7 @@ mod can_execute_tests {
 
   #[test]
   fn pair_state_shape_mismatch() {
-    let order = lst_order_s2l_at_above_trigger();
+    let order = lst_order_stable_to_lever_at_above_trigger();
     let hylo = healthy_hylo(978);
     let mut exo_order = order;
     exo_order.pair_target = PairTarget::Exo {
@@ -384,7 +385,7 @@ mod can_execute_tests {
 
   #[test]
   fn exo_met_and_healthy_returns_ok() {
-    let order = exo_order_s2l_at_above_trigger();
+    let order = exo_order_stable_to_lever_at_above_trigger();
     let hylo = healthy_hylo(978);
     let exo_pair = healthy_exo_pair(978);
     assert!(order
@@ -394,7 +395,7 @@ mod can_execute_tests {
 
   #[test]
   fn exo_pair_paused_returns_exo_pair_paused() {
-    let order = exo_order_s2l_at_above_trigger();
+    let order = exo_order_stable_to_lever_at_above_trigger();
     let hylo = healthy_hylo(978);
     let mut exo_pair = healthy_exo_pair(978);
     exo_pair.paused = true;
@@ -406,7 +407,7 @@ mod can_execute_tests {
 
   #[test]
   fn exo_drawdown_outstanding_returns_drawdown_not_repaid() {
-    let order = exo_order_s2l_at_above_trigger();
+    let order = exo_order_stable_to_lever_at_above_trigger();
     let hylo = healthy_hylo(978);
     let mut exo_pair = healthy_exo_pair(978);
     exo_pair.pool_drawdown.ledger.supply.bits = 1;
@@ -418,7 +419,7 @@ mod can_execute_tests {
 
   #[test]
   fn exo_borrow_rate_harvest_stale_returns_stale() {
-    let order = exo_order_s2l_at_above_trigger();
+    let order = exo_order_stable_to_lever_at_above_trigger();
     let hylo = healthy_hylo(978);
     let exo_pair = healthy_exo_pair(977); // one epoch behind
     assert_eq!(
@@ -429,7 +430,7 @@ mod can_execute_tests {
 
   #[test]
   fn lst_order_with_some_exo_pair_returns_pair_state_mismatch() {
-    let order = lst_order_s2l_at_above_trigger();
+    let order = lst_order_stable_to_lever_at_above_trigger();
     let hylo = healthy_hylo(978);
     let exo_pair = healthy_exo_pair(978);
     assert_eq!(
@@ -445,8 +446,8 @@ mod tag_tests {
 
   #[test]
   fn convert_direction_tags() {
-    assert_eq!(ConvertDirection::S2L_TAG, 0);
-    assert_eq!(ConvertDirection::L2S_TAG, 1);
+    assert_eq!(ConvertDirection::STABLE_TO_LEVER_TAG, 0);
+    assert_eq!(ConvertDirection::LEVER_TO_STABLE_TAG, 1);
     assert_eq!(ConvertDirection::StableToLever.tag_byte(), 0);
     assert_eq!(ConvertDirection::LeverToStable.tag_byte(), 1);
   }
@@ -501,6 +502,7 @@ mod evaluate_trigger_tests {
       direction,
       created_at: 0,
       bump: 0,
+      _reserved: [0u8; 64],
     }
   }
 

--- a/hylo-idl/src/trigger_orders_ext.rs
+++ b/hylo-idl/src/trigger_orders_ext.rs
@@ -2,7 +2,16 @@
 //! types. Lives in `hylo-idl` because Rust's orphan rule forbids `impl`s
 //! on generated types from a foreign crate.
 
+use crate::trigger_orders::accounts::TriggerOrder;
 use crate::trigger_orders::types::{ConvertDirection, PairTarget};
+
+impl TriggerOrder {
+  /// Byte offset of the `owner` field within the serialized account
+  /// (after the 8-byte Anchor discriminator). Used as the `memcmp` offset
+  /// in `getProgramAccounts` filters keyed by owner. If a future migration
+  /// inserts a field before `owner`, update this constant.
+  pub const OWNER_OFFSET: usize = 8;
+}
 
 impl ConvertDirection {
   /// PDA seed-slice tag for `StableToLever` orders. Must match
@@ -63,5 +72,16 @@ mod tag_tests {
       .tag_byte(),
       1
     );
+  }
+}
+
+#[cfg(test)]
+mod owner_offset_tests {
+  use crate::trigger_orders::accounts::TriggerOrder;
+
+  #[test]
+  fn owner_offset_is_post_discriminator() {
+    // Anchor 8-byte discriminator + owner as first struct field => offset 8.
+    assert_eq!(TriggerOrder::OWNER_OFFSET, 8);
   }
 }

--- a/hylo-idl/src/trigger_orders_ext.rs
+++ b/hylo-idl/src/trigger_orders_ext.rs
@@ -3,7 +3,49 @@
 //! on generated types from a foreign crate.
 
 use crate::trigger_orders::accounts::TriggerOrder;
-use crate::trigger_orders::types::{ConvertDirection, PairTarget};
+use crate::trigger_orders::types::{
+  ConvertDirection, PairTarget, TriggerDirection,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TriggerOutcome {
+  /// Price condition satisfied. Execute may proceed (subject to chain
+  /// gates surfaced by `TriggerOrder::can_execute` or
+  /// `TriggerOrdersClient::simulate_execute_order_*`).
+  Met,
+  /// Price condition not satisfied at the snapshot.
+  NotMet,
+  /// Pyth expo on the snapshot doesn't match the order's stored expo.
+  /// Order cannot execute until owner cancels and re-creates with the
+  /// current expo. Mirrors on-chain `require_eq!(m.exponent,
+  /// order.trigger_expo)`.
+  ExpoMismatch,
+}
+
+impl TriggerOrder {
+  /// Pure check against a Pyth price snapshot. No chain reads. Returns
+  /// [`TriggerOutcome::ExpoMismatch`] if `pyth_expo` doesn't match the
+  /// order's stored `trigger_expo`.
+  #[must_use]
+  pub fn evaluate_trigger(
+    &self,
+    pyth_price: i64,
+    pyth_expo: i32,
+  ) -> TriggerOutcome {
+    if pyth_expo != self.trigger_expo {
+      return TriggerOutcome::ExpoMismatch;
+    }
+    let ok = match self.direction {
+      TriggerDirection::AtOrBelow => pyth_price <= self.trigger_price,
+      TriggerDirection::AtOrAbove => pyth_price >= self.trigger_price,
+    };
+    if ok {
+      TriggerOutcome::Met
+    } else {
+      TriggerOutcome::NotMet
+    }
+  }
+}
 
 impl TriggerOrder {
   /// Byte offset of the `owner` field within the serialized account
@@ -83,5 +125,90 @@ mod owner_offset_tests {
   fn owner_offset_is_post_discriminator() {
     // Anchor 8-byte discriminator + owner as first struct field => offset 8.
     assert_eq!(TriggerOrder::OWNER_OFFSET, 8);
+  }
+}
+
+#[cfg(test)]
+mod evaluate_trigger_tests {
+  use anchor_lang::prelude::Pubkey;
+
+  use super::*;
+  use crate::trigger_orders::types::TriggerDirection;
+
+  fn order(
+    trigger_price: i64,
+    trigger_expo: i32,
+    direction: TriggerDirection,
+  ) -> TriggerOrder {
+    TriggerOrder {
+      owner: Pubkey::default(),
+      pair_target: PairTarget::Lst,
+      convert_direction: ConvertDirection::StableToLever,
+      nonce: 0,
+      escrow_amount: 0,
+      trigger_price,
+      trigger_expo,
+      direction,
+      created_at: 0,
+      bump: 0,
+    }
+  }
+
+  #[test]
+  fn above_met_when_pyth_higher() {
+    assert_eq!(
+      order(100, -8, TriggerDirection::AtOrAbove).evaluate_trigger(150, -8),
+      TriggerOutcome::Met,
+    );
+  }
+
+  #[test]
+  fn above_met_at_equality() {
+    assert_eq!(
+      order(100, -8, TriggerDirection::AtOrAbove).evaluate_trigger(100, -8),
+      TriggerOutcome::Met,
+    );
+  }
+
+  #[test]
+  fn above_not_met_when_pyth_lower() {
+    assert_eq!(
+      order(100, -8, TriggerDirection::AtOrAbove).evaluate_trigger(50, -8),
+      TriggerOutcome::NotMet,
+    );
+  }
+
+  #[test]
+  fn below_met_when_pyth_lower() {
+    assert_eq!(
+      order(100, -8, TriggerDirection::AtOrBelow).evaluate_trigger(50, -8),
+      TriggerOutcome::Met,
+    );
+  }
+
+  #[test]
+  fn below_met_at_equality() {
+    assert_eq!(
+      order(100, -8, TriggerDirection::AtOrBelow).evaluate_trigger(100, -8),
+      TriggerOutcome::Met,
+    );
+  }
+
+  #[test]
+  fn below_not_met_when_pyth_higher() {
+    assert_eq!(
+      order(100, -8, TriggerDirection::AtOrBelow).evaluate_trigger(150, -8),
+      TriggerOutcome::NotMet,
+    );
+  }
+
+  #[test]
+  fn expo_mismatch_short_circuits_regardless_of_price() {
+    let o = order(100, -8, TriggerDirection::AtOrAbove);
+    assert_eq!(
+      o.evaluate_trigger(1_000_000, -6),
+      TriggerOutcome::ExpoMismatch
+    );
+    assert_eq!(o.evaluate_trigger(0, -10), TriggerOutcome::ExpoMismatch);
   }
 }

--- a/hylo-idl/src/trigger_orders_ext.rs
+++ b/hylo-idl/src/trigger_orders_ext.rs
@@ -224,7 +224,6 @@ mod can_execute_tests {
       direction: TriggerDirection::AtOrAbove,
       created_at: 0,
       bump: 0,
-      _reserved: [0u8; 64],
     }
   }
 
@@ -502,7 +501,6 @@ mod evaluate_trigger_tests {
       direction,
       created_at: 0,
       bump: 0,
-      _reserved: [0u8; 64],
     }
   }
 

--- a/hylo-idl/src/trigger_orders_ext.rs
+++ b/hylo-idl/src/trigger_orders_ext.rs
@@ -2,6 +2,7 @@
 //! types. Lives in `hylo-idl` because Rust's orphan rule forbids `impl`s
 //! on generated types from a foreign crate.
 
+use crate::exchange::accounts::{ExoPair, Hylo};
 use crate::trigger_orders::accounts::TriggerOrder;
 use crate::trigger_orders::types::{
   ConvertDirection, PairTarget, TriggerDirection,
@@ -86,6 +87,355 @@ impl PairTarget {
       Self::Lst => Self::LST_TAG,
       Self::Exo { .. } => Self::EXO_TAG,
     }
+  }
+}
+
+/// Why an otherwise-triggered order would still fail right now. The
+/// variants `StableToLeverDisabled` / `LeverToStableDisabled` are
+/// returned ONLY by `TriggerOrdersClient::simulate_execute_order_*` —
+/// not by [`TriggerOrder::can_execute`], which doesn't replicate the
+/// on-chain CR-gate predicate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExecutabilityBlocker {
+  /// Pyth snapshot doesn't satisfy the trigger.
+  TriggerNotMet,
+  /// Pyth expo on the snapshot doesn't match the order's stored expo.
+  ExpoMismatch,
+  /// `Hylo.protocol_paused` is true.
+  ProtocolPaused,
+  /// `Hylo.lst_pair_paused` is true (LST orders only).
+  LstPairPaused,
+  /// `ExoPair.paused` is true (EXO orders only).
+  ExoPairPaused,
+  /// `pool_drawdown.ledger.supply.bits > 0` on the relevant pair state.
+  DrawdownNotRepaid,
+  /// `levercoin_mint_enabled()` is false (Depeg). Returned by simulation only.
+  StableToLeverDisabled,
+  /// `stablecoin_mint_enabled()` is false (CR below threshold, ~1.35).
+  /// Returned by simulation only. The asymmetric regime.
+  LeverToStableDisabled,
+  /// `yield_harvest_cache.epoch < current_epoch` (LST orders).
+  YieldHarvestStale,
+  /// `borrow_rate_harvest_cache.epoch < current_epoch` (EXO orders).
+  BorrowRateHarvestStale,
+  /// Caller passed `exo_pair: Some` for an LST order, or `None` for an EXO.
+  PairStateMismatch,
+}
+
+impl TriggerOrder {
+  /// Returns `Ok(())` if the order would execute against the supplied
+  /// chain state for the gates this method can evaluate cheaply.
+  ///
+  /// **Does NOT replicate the on-chain CR-gate.** The asymmetric
+  /// `levercoin_mint_enabled` / `stablecoin_mint_enabled` predicates
+  /// live on `LstExchangeContext` / `ExoExchangeContext` and require a
+  /// full exchange-context load with Pyth, fees, and rebalance configs.
+  /// Keepers should call `TriggerOrdersClient::simulate_execute_order_*`
+  /// after `can_execute` returns `Ok` to discover CR-gate blockers via
+  /// the actual revert. As a result, this method NEVER returns
+  /// [`ExecutabilityBlocker::StableToLeverDisabled`] or
+  /// [`ExecutabilityBlocker::LeverToStableDisabled`].
+  ///
+  /// # Errors
+  /// Returns the first blocker found, in on-chain check order.
+  pub fn can_execute(
+    &self,
+    hylo: &Hylo,
+    exo_pair: Option<&ExoPair>,
+    pyth_price: i64,
+    pyth_expo: i32,
+    current_epoch: u64,
+  ) -> Result<(), ExecutabilityBlocker> {
+    // 1. Pair-state shape.
+    let is_exo = matches!(self.pair_target, PairTarget::Exo { .. });
+    if is_exo != exo_pair.is_some() {
+      return Err(ExecutabilityBlocker::PairStateMismatch);
+    }
+
+    // 2. Trigger.
+    match self.evaluate_trigger(pyth_price, pyth_expo) {
+      TriggerOutcome::Met => {}
+      TriggerOutcome::NotMet => {
+        return Err(ExecutabilityBlocker::TriggerNotMet)
+      }
+      TriggerOutcome::ExpoMismatch => {
+        return Err(ExecutabilityBlocker::ExpoMismatch)
+      }
+    }
+
+    // 3. Pauses.
+    if hylo.protocol_paused {
+      return Err(ExecutabilityBlocker::ProtocolPaused);
+    }
+    if let Some(pair) = exo_pair {
+      if pair.paused {
+        return Err(ExecutabilityBlocker::ExoPairPaused);
+      }
+    } else if hylo.lst_pair_paused {
+      return Err(ExecutabilityBlocker::LstPairPaused);
+    }
+
+    // 4. Drawdown repaid?
+    let drawdown_outstanding = exo_pair
+      .map_or(hylo.pool_drawdown.ledger.supply.bits != 0, |p| {
+        p.pool_drawdown.ledger.supply.bits != 0
+      });
+    if drawdown_outstanding {
+      return Err(ExecutabilityBlocker::DrawdownNotRepaid);
+    }
+
+    // 5. Harvest staleness.
+    if let Some(pair) = exo_pair {
+      if pair.borrow_rate_harvest_cache.epoch < current_epoch {
+        return Err(ExecutabilityBlocker::BorrowRateHarvestStale);
+      }
+    } else if hylo.yield_harvest_cache.epoch < current_epoch {
+      return Err(ExecutabilityBlocker::YieldHarvestStale);
+    }
+
+    // CR-gate intentionally omitted — see docstring.
+    Ok(())
+  }
+}
+
+#[cfg(test)]
+mod can_execute_tests {
+  use anchor_lang::prelude::Pubkey;
+
+  use super::*;
+  use crate::exchange::accounts::Hylo;
+  use crate::exchange::types::{
+    BorrowRateConfig, HarvestCache, LevercoinFees, PoolDrawdown,
+    RebalanceCurveConfig, UFixValue64, VirtualStablecoin,
+  };
+  use crate::trigger_orders::types::TriggerDirection;
+
+  // `TriggerOrder` intentionally does NOT derive `Default`, so this fixture
+  // lists every field explicitly — adding a field forces it to be updated.
+  fn lst_order_s2l_at_above_trigger() -> TriggerOrder {
+    TriggerOrder {
+      owner: Pubkey::default(),
+      pair_target: PairTarget::Lst,
+      convert_direction: ConvertDirection::StableToLever,
+      nonce: 0,
+      escrow_amount: 0,
+      trigger_price: 100,
+      trigger_expo: -8,
+      direction: TriggerDirection::AtOrAbove,
+      created_at: 0,
+      bump: 0,
+    }
+  }
+
+  // An `Exo`-variant order at-or-above its trigger. Clones the LST fixture
+  // and swaps the pair target so the EXO code paths in `can_execute` are
+  // exercised. (`TriggerOrder` is `Copy`, so the clone is a plain reassign.)
+  fn exo_order_s2l_at_above_trigger() -> TriggerOrder {
+    let mut order = lst_order_s2l_at_above_trigger();
+    order.pair_target = PairTarget::Exo {
+      collateral_mint: Pubkey::new_unique(),
+    };
+    order
+  }
+
+  // NOTE: unlike `Hylo`, `ExoPair` does NOT derive `Default` — its
+  // `_reserved: [u8; 100]` field exceeds the 32-element array limit for which
+  // `Default` is auto-implemented, so the macro can't derive it. We therefore
+  // list every field explicitly, using `Default::default()` for the embedded
+  // sub-structs the tests don't exercise (those are all small enough to derive
+  // `Default`) and overriding only `paused`, `pool_drawdown`, and
+  // `borrow_rate_harvest_cache`.
+  fn healthy_exo_pair(current_epoch: u64) -> ExoPair {
+    ExoPair {
+      collateral_mint: Pubkey::new_unique(),
+      levercoin_mint_bump: 0,
+      levercoin_auth_bump: 0,
+      vault_auth_bump: 0,
+      fee_auth_bump: 0,
+      oracle: Pubkey::new_unique(),
+      oracle_feed_id: [0u8; 32],
+      oracle_interval_secs: 30,
+      oracle_conf_tolerance: UFixValue64::default(),
+      stablecoin_mint_threshold: UFixValue64::default(),
+      virtual_stablecoin: VirtualStablecoin::default(),
+      borrow_rate_config: BorrowRateConfig::default(),
+      borrow_rate_harvest_cache: HarvestCache {
+        epoch: current_epoch,
+        ..Default::default()
+      },
+      levercoin_fees: LevercoinFees::default(),
+      sell_curve_config: RebalanceCurveConfig::default(),
+      buy_curve_config: RebalanceCurveConfig::default(),
+      rebalance_deviation_tolerance: UFixValue64::default(),
+      paused: false,
+      levercoin_market_cap_limit: UFixValue64::default(),
+      pool_drawdown: PoolDrawdown {
+        ledger: VirtualStablecoin {
+          supply: UFixValue64 { bits: 0, exp: 0 },
+        },
+      },
+      _reserved: [0u8; 100],
+    }
+  }
+
+  // `Hylo` derives `Default` (every embedded type does too), so use
+  // `..Default::default()` and override only the fields the test exercises.
+  fn healthy_hylo(current_epoch: u64) -> Hylo {
+    Hylo {
+      oracle_interval_secs: 30,
+      yield_harvest_cache: HarvestCache {
+        epoch: current_epoch,
+        ..Default::default()
+      },
+      protocol_paused: false,
+      lst_pair_paused: false,
+      pool_drawdown: PoolDrawdown {
+        ledger: VirtualStablecoin {
+          supply: UFixValue64 { bits: 0, exp: 0 },
+        },
+      },
+      ..Default::default()
+    }
+  }
+
+  #[test]
+  fn met_and_healthy_returns_ok() {
+    let order = lst_order_s2l_at_above_trigger();
+    let hylo = healthy_hylo(978);
+    assert!(order.can_execute(&hylo, None, 150, -8, 978).is_ok());
+  }
+
+  #[test]
+  fn trigger_not_met_returns_trigger_not_met() {
+    let order = lst_order_s2l_at_above_trigger();
+    let hylo = healthy_hylo(978);
+    assert_eq!(
+      order.can_execute(&hylo, None, 50, -8, 978),
+      Err(ExecutabilityBlocker::TriggerNotMet),
+    );
+  }
+
+  #[test]
+  fn expo_mismatch_returns_expo_mismatch() {
+    let order = lst_order_s2l_at_above_trigger();
+    let hylo = healthy_hylo(978);
+    assert_eq!(
+      order.can_execute(&hylo, None, 150, -6, 978),
+      Err(ExecutabilityBlocker::ExpoMismatch),
+    );
+  }
+
+  #[test]
+  fn protocol_paused_returns_protocol_paused() {
+    let order = lst_order_s2l_at_above_trigger();
+    let mut hylo = healthy_hylo(978);
+    hylo.protocol_paused = true;
+    assert_eq!(
+      order.can_execute(&hylo, None, 150, -8, 978),
+      Err(ExecutabilityBlocker::ProtocolPaused),
+    );
+  }
+
+  #[test]
+  fn lst_pair_paused_returns_lst_pair_paused() {
+    let order = lst_order_s2l_at_above_trigger();
+    let mut hylo = healthy_hylo(978);
+    hylo.lst_pair_paused = true;
+    assert_eq!(
+      order.can_execute(&hylo, None, 150, -8, 978),
+      Err(ExecutabilityBlocker::LstPairPaused),
+    );
+  }
+
+  #[test]
+  fn drawdown_outstanding_returns_drawdown_not_repaid() {
+    let order = lst_order_s2l_at_above_trigger();
+    let mut hylo = healthy_hylo(978);
+    hylo.pool_drawdown.ledger.supply.bits = 1;
+    assert_eq!(
+      order.can_execute(&hylo, None, 150, -8, 978),
+      Err(ExecutabilityBlocker::DrawdownNotRepaid),
+    );
+  }
+
+  #[test]
+  fn yield_harvest_stale_returns_stale() {
+    let order = lst_order_s2l_at_above_trigger();
+    let hylo = healthy_hylo(977); // one epoch behind
+    assert_eq!(
+      order.can_execute(&hylo, None, 150, -8, 978),
+      Err(ExecutabilityBlocker::YieldHarvestStale),
+    );
+  }
+
+  #[test]
+  fn pair_state_shape_mismatch() {
+    let order = lst_order_s2l_at_above_trigger();
+    let hylo = healthy_hylo(978);
+    let mut exo_order = order;
+    exo_order.pair_target = PairTarget::Exo {
+      collateral_mint: Pubkey::new_unique(),
+    };
+    assert_eq!(
+      exo_order.can_execute(&hylo, None, 150, -8, 978),
+      Err(ExecutabilityBlocker::PairStateMismatch),
+    );
+  }
+
+  #[test]
+  fn exo_met_and_healthy_returns_ok() {
+    let order = exo_order_s2l_at_above_trigger();
+    let hylo = healthy_hylo(978);
+    let exo_pair = healthy_exo_pair(978);
+    assert!(order
+      .can_execute(&hylo, Some(&exo_pair), 150, -8, 978)
+      .is_ok());
+  }
+
+  #[test]
+  fn exo_pair_paused_returns_exo_pair_paused() {
+    let order = exo_order_s2l_at_above_trigger();
+    let hylo = healthy_hylo(978);
+    let mut exo_pair = healthy_exo_pair(978);
+    exo_pair.paused = true;
+    assert_eq!(
+      order.can_execute(&hylo, Some(&exo_pair), 150, -8, 978),
+      Err(ExecutabilityBlocker::ExoPairPaused),
+    );
+  }
+
+  #[test]
+  fn exo_drawdown_outstanding_returns_drawdown_not_repaid() {
+    let order = exo_order_s2l_at_above_trigger();
+    let hylo = healthy_hylo(978);
+    let mut exo_pair = healthy_exo_pair(978);
+    exo_pair.pool_drawdown.ledger.supply.bits = 1;
+    assert_eq!(
+      order.can_execute(&hylo, Some(&exo_pair), 150, -8, 978),
+      Err(ExecutabilityBlocker::DrawdownNotRepaid),
+    );
+  }
+
+  #[test]
+  fn exo_borrow_rate_harvest_stale_returns_stale() {
+    let order = exo_order_s2l_at_above_trigger();
+    let hylo = healthy_hylo(978);
+    let exo_pair = healthy_exo_pair(977); // one epoch behind
+    assert_eq!(
+      order.can_execute(&hylo, Some(&exo_pair), 150, -8, 978),
+      Err(ExecutabilityBlocker::BorrowRateHarvestStale),
+    );
+  }
+
+  #[test]
+  fn lst_order_with_some_exo_pair_returns_pair_state_mismatch() {
+    let order = lst_order_s2l_at_above_trigger();
+    let hylo = healthy_hylo(978);
+    let exo_pair = healthy_exo_pair(978);
+    assert_eq!(
+      order.can_execute(&hylo, Some(&exo_pair), 150, -8, 978),
+      Err(ExecutabilityBlocker::PairStateMismatch),
+    );
   }
 }
 


### PR DESCRIPTION
Typed IDL bindings + TriggerOrdersClient for the trigger-orders program (create/cancel/execute/simulate/get/list), stable_to_lever/lever_to_stable naming, mainnet+shadow IDLs. Includes the conventions refactor (already merged into this branch). Green both configs.