### PR TITLE
Inline Pyth feed addresses in hylo-core

### DIFF
--- a/hylo-core/src/pyth.rs
+++ b/hylo-core/src/pyth.rs
@@ -1,7 +1,6 @@
 use anchor_lang::prelude::*;
 use fix::prelude::*;
 use fix::typenum::{Integer, Z0};
-use hylo_idl::pda::{BTC_USD_PYTH_FEED, SOL_USD_PYTH_FEED, USDC_USD_PYTH_FEED};
 use pyth_solana_receiver_sdk::price_update::{
   FeedId, PriceUpdateV2, VerificationLevel,
 };
@@ -29,7 +28,7 @@ pub const SOL_USD: PythFeed = PythFeed {
     239, 13, 139, 111, 218, 44, 235, 164, 29, 161, 93, 64, 149, 209, 218, 57,
     42, 13, 47, 142, 208, 198, 199, 188, 15, 76, 250, 200, 194, 128, 181, 109,
   ],
-  address: SOL_USD_PYTH_FEED,
+  address: pubkey!("7AviUf9nL62mcxNbQGKm4nKDQnPjswo6c5MX4D57HmyE"),
 };
 
 pub const BTC_USD: PythFeed = PythFeed {
@@ -37,7 +36,7 @@ pub const BTC_USD: PythFeed = PythFeed {
     230, 45, 246, 200, 180, 168, 95, 225, 166, 125, 180, 77, 193, 45, 229, 219,
     51, 15, 122, 198, 107, 114, 220, 101, 138, 254, 223, 15, 74, 65, 91, 67,
   ],
-  address: BTC_USD_PYTH_FEED,
+  address: pubkey!("APgzQGGdv2qCgBkX6aHVkrGePtBVDDg68GiqaM7rmtf5"),
 };
 
 pub const USDC_USD: PythFeed = PythFeed {
@@ -45,7 +44,7 @@ pub const USDC_USD: PythFeed = PythFeed {
     234, 160, 32, 198, 28, 196, 121, 113, 40, 19, 70, 28, 225, 83, 137, 74,
     150, 166, 192, 11, 33, 237, 12, 252, 39, 152, 209, 249, 169, 233, 201, 74,
   ],
-  address: USDC_USD_PYTH_FEED,
+  address: pubkey!("6HAuqASbHEh4w4REJEUUUCginTLfj1kwCh215ZLtMkrT"),
 };
 
 #[derive(Copy, Clone)]


### PR DESCRIPTION
#68 pointed `hylo-core::pyth` at `hylo_idl::pda` constants to dedup addresses. But `hylo-core` builds on-chain **without** the `offchain` feature, where `hylo-idl` isn't linked — so any downstream on-chain build (the protocol) fails with:

```
error[E0433]: failed to resolve: use of unresolved module or unlinked crate `hylo_idl`
```

Re-exporting the other direction would create a dependency cycle (`hylo-core[offchain] → hylo-idl → hylo-core`), so the feed pubkeys are inlined back into `hylo-core::pyth` with the updated #68 values. `hylo-idl::pda` keeps its copies for offchain consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)